### PR TITLE
ext: hal: add new API to get stm32 ipcc num of channel

### DIFF
--- a/stm32cube/stm32mp1xx/README
+++ b/stm32cube/stm32mp1xx/README
@@ -54,3 +54,9 @@ Patch List:
       ext/hal/st/stm32cube/stm32mp1xx/README
       ext/hal/st/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_rcc.h
     ST Bug tracker ID: BZ65410
+
+    * Add new API to get stm32 ipcc num of channel
+    allow to read the The IPCC peripheral HWCFGR register to get IPCC number of channels capability.
+    Impacted files:
+       ext/hal/st/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_rcc.h
+    ST Bug tracker ID: 68247

--- a/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_ipcc.h
+++ b/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_ipcc.h
@@ -696,6 +696,17 @@ __STATIC_INLINE uint32_t LL_C2_IPCC_IsActiveFlag_CHx(IPCC_TypeDef  const *const 
 }
 
 /**
+  * @brief  get channels configuration.
+  * @rmtoll HWCFGR        CHANNELS         LL_IPCC_GetChannelConfig
+  * @param  IPCCx IPCC Instance.
+  * @retval number of channnels supported
+  */
+__STATIC_INLINE uint32_t LL_IPCC_GetChannelConfig(IPCC_TypeDef *IPCCx)
+{
+  return READ_BIT(IPCCx->HWCFGR, IPCC_HWCFGR_CHANNELS) >> IPCC_HWCFGR_CHANNELS_Pos;
+}
+
+/**
   * @}
   */
 


### PR DESCRIPTION
Add API to read the The IPCC peripheral HWCFGR register and return the
number of channels capability.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>