### PR TITLE
stm32l151xb: add missing SPI_CR2_FRF definitions

### DIFF
--- a/stm32cube/stm32l1xx/README
+++ b/stm32cube/stm32l1xx/README
@@ -84,3 +84,10 @@ Patch List:
     Impacted files:
      drivers/include/stm32l1xx_hal_conf.h
     ST Bug tracker ID: NA. Not a stm32cube issue
+
+   *stm32l151xb: add missing SPI_CR2_FRF definitions
+
+    The higher density parts correctly included the SPI_CR2_FRF definitions,
+    but these were missing for the low/medium density parts.  Without these
+    definitions, the zephyr SPI driver cannot be used on these parts.
+    ST Bug tracker ID: 73643

--- a/stm32cube/stm32l1xx/soc/stm32l151xb.h
+++ b/stm32cube/stm32l1xx/soc/stm32l151xb.h
@@ -5012,6 +5012,9 @@ typedef struct
 #define SPI_CR2_SSOE_Pos                    (2U)
 #define SPI_CR2_SSOE_Msk                    (0x1UL << SPI_CR2_SSOE_Pos)         /*!< 0x00000004 */
 #define SPI_CR2_SSOE                        SPI_CR2_SSOE_Msk                   /*!< SS Output Enable */
+#define SPI_CR2_FRF_Pos                     (4U)
+#define SPI_CR2_FRF_Msk                     (0x1UL << SPI_CR2_FRF_Pos)          /*!< 0x00000010 */
+#define SPI_CR2_FRF                         SPI_CR2_FRF_Msk                    /*!< Frame format */
 #define SPI_CR2_ERRIE_Pos                   (5U)
 #define SPI_CR2_ERRIE_Msk                   (0x1UL << SPI_CR2_ERRIE_Pos)        /*!< 0x00000020 */
 #define SPI_CR2_ERRIE                       SPI_CR2_ERRIE_Msk                  /*!< Error Interrupt Enable */

--- a/stm32cube/stm32l1xx/soc/stm32l151xba.h
+++ b/stm32cube/stm32l1xx/soc/stm32l151xba.h
@@ -5088,6 +5088,9 @@ typedef struct
 #define SPI_CR2_SSOE_Pos                    (2U)
 #define SPI_CR2_SSOE_Msk                    (0x1UL << SPI_CR2_SSOE_Pos)         /*!< 0x00000004 */
 #define SPI_CR2_SSOE                        SPI_CR2_SSOE_Msk                   /*!< SS Output Enable */
+#define SPI_CR2_FRF_Pos                     (4U)
+#define SPI_CR2_FRF_Msk                     (0x1UL << SPI_CR2_FRF_Pos)          /*!< 0x00000010 */
+#define SPI_CR2_FRF                         SPI_CR2_FRF_Msk                    /*!< Frame format */
 #define SPI_CR2_ERRIE_Pos                   (5U)
 #define SPI_CR2_ERRIE_Msk                   (0x1UL << SPI_CR2_ERRIE_Pos)        /*!< 0x00000020 */
 #define SPI_CR2_ERRIE                       SPI_CR2_ERRIE_Msk                  /*!< Error Interrupt Enable */


### PR DESCRIPTION
This is a bug in upstream CMSIS, but I don't have any contacts to get it
fixed there.

Signed-off-by: Karl Palsson <karlp@etactica.com>