### PR TITLE
script: build new zephyr module from a new STM32Cube

### DIFF
--- a/scripts/make_stm32_module.py
+++ b/scripts/make_stm32_module.py
@@ -1,0 +1,322 @@
+#!/usr/bin/python
+
+# Copyright (c) 2019 STMicroelectronics.
+# This script will build module, readme and CMakelists.txt files
+# to use with zephyr_module.py
+
+import os
+import subprocess
+
+##############################################################################
+# create the module for zephyr in a new folder named '.<current_version>'
+# where the <current_version> is the checkout one
+# in the current directory( $HOME/STM32Cube/STM32CubeXX)
+
+
+def module(make_serie):
+
+    make_path = os.getcwd()
+
+    if 'stm32' not in make_serie:
+        make_serie = 'stm32' + make_serie    # example 'stm32f3'
+
+    make_seriexx = make_serie.lower() + "xx"    # example 'stm32f3xx'
+    make_SERIE = make_serie.upper()    # example 'STM32F3'
+    make_SERIExx = make_SERIE + "xx"    # example 'STM32F3xx'
+
+    # build and populate new directories from the repo :  .versionID
+    # build the new zephyr module from the stm32cube
+    make_repo = os.path.join(os.getenv("HOME"),
+                             "STM32Cube_repo/STM32Cube" + make_SERIE[5:])
+    # identify the version being made
+    if not os.path.isdir(make_repo):
+        return "Error : directory " + make_repo + " does not exist"
+    else:
+        os.chdir(make_repo)
+
+    make_version = subprocess.check_output("git describe --tags", shell=True)[:-1]
+    make_path = os.path.join(make_path, make_seriexx + "." + make_version)
+
+    if os.path.exists(make_path):
+        return "Error : directory " + make_path + " already exists"
+    else:
+        os.mkdir(make_path)
+
+    #  for CMSIS files
+    os.mkdir(os.path.join(make_path, "soc"))
+    for repo_file in os.listdir(os.path.join(make_repo, "Drivers/CMSIS/Device/ST",
+                                             make_SERIExx, "Include")):
+        repo_src = os.path.join(make_repo, "Drivers/CMSIS/Device/ST",
+                                make_SERIExx, "Include", repo_file)
+        repo_dst = os.path.join(make_path, "soc", repo_file)
+        os.rename(repo_src, repo_dst)
+
+    for repo_file in os.listdir(os.path.join(make_repo, "Drivers/CMSIS/Device/ST",
+                                             make_SERIExx, "Source/Templates")):
+        repo_src = os.path.join(make_repo, "Drivers/CMSIS/Device/ST",
+                                make_SERIExx, "Source/Templates", repo_file)
+        if os.path.isfile(repo_src):
+            repo_dst = os.path.join(make_path, "soc", repo_file)
+            os.rename(repo_src, repo_dst)
+
+    # for hal and ll drivers
+    os.mkdir(os.path.join(make_path, "drivers"))
+
+    os.mkdir(os.path.join(make_path, "drivers/include"))
+    for repo_file in os.listdir(os.path.join(make_repo,
+                                             "Drivers",
+                                             make_SERIExx + "_HAL_Driver/Inc")):
+        repo_src = os.path.join(make_repo, "Drivers",
+                                make_SERIExx + "_HAL_Driver/Inc", repo_file)
+        repo_dst = os.path.join(make_path, "drivers", "include", repo_file)
+        os.renames(repo_src, repo_dst)
+
+    # except for _hal_conf_template.h
+    temp = [f for f in os.listdir(os.path.join(make_path, "drivers", "include")) if 'hal_conf_template.h' in f]
+    if os.path.isfile(os.path.join(make_path, "drivers", "include", temp[0])):
+        os.rename(os.path.join(make_path, "drivers", "include", temp[0]),
+                  os.path.join(make_path, "drivers", "include",
+                  os.path.splitext(temp[0])[0][:-9] + '.h'))
+
+    os.mkdir(os.path.join(make_path, "drivers/src"))
+    for repo_file in os.listdir(os.path.join(make_repo, "Drivers",
+                                             make_SERIExx + "_HAL_Driver/Src")):
+        repo_src = os.path.join(make_repo, "Drivers",
+                                make_SERIExx + "_HAL_Driver/Src", repo_file)
+        repo_dst = os.path.join(make_path, "drivers", "src", repo_file)
+        os.rename(repo_src, repo_dst)
+
+    return make_path
+
+##############################################################################
+# into the current dir = ./module/stm32cube/stm32<serie>xx
+
+
+def readme(make_serie, make_version, make_commit):
+    if 'stm32' not in make_serie:
+        make_serie = 'stm32' + make_serie         # example 'stm32f3'
+
+    make_seriexx = make_serie.lower() + "xx"      # example 'stm32f3xx'
+    make_SERIE = make_serie.upper()               # example 'STM32F3'
+
+    if os.path.exists(os.path.join('./stm32cube', make_seriexx, 'README')):
+        # build new README from previous one if exists
+        readme_file = open(os.path.join('./stm32cube',
+                                        make_seriexx, 'README.new'), 'w')
+    else:
+        print 'Error: no README file'
+        return
+
+    with open(os.path.join('./stm32cube', make_seriexx, 'README'), 'r') as readme_prev:
+        Lines = enumerate(readme_prev.read().splitlines())
+        readme_prev.close()
+
+    for LineItem in Lines:
+        # change version nb
+        if "status" in LineItem[1].lower():
+            readme_file.write("Status:\n")
+            readme_file.write("   version {0}\n".format(make_version))
+            Lines.next()        # skip next line
+        elif "commit" in LineItem[1].lower():
+            readme_file.write("Commit:\n")
+            readme_file.write("   {0}".format(make_commit))
+            Lines.next()        # skip next line
+        elif "URL" in LineItem[1].upper():
+            readme_file.write("URL:\n")
+            readme_file.write("   https://github.com/STMicroelectronics/STM32Cube{0}\n".format(make_SERIE[5:]))
+            Lines.next()        # skip next line
+        # change patch list with a link to the release_note.html
+        elif "Patch List" in LineItem[1]:
+            readme_file.write("Patch List:\n")
+            readme_file.write("--> please check that the following list is still valid:\n")
+        else:
+            readme_file.write("{0}\n".format(LineItem[1]))
+            # at the very end of the file :
+
+    readme_file.write("\n   See release_note.html from STM32Cube\n")
+
+    readme_file.flush()
+    readme_file.close()
+
+    os.rename(os.path.join('./stm32cube', make_seriexx, 'README.new'),
+              os.path.join('./stm32cube', make_seriexx, 'README'))
+
+####################################################################################################
+# build the CMakeLists.txt file
+# into the current dir = ./module/stm32cube/stm32<serie>xx
+
+
+def makelist(make_serie):
+    if 'stm32' not in make_serie:
+        make_serie = 'stm32' + make_serie            # example 'stm32f3'
+
+    make_seriexx = make_serie.lower() + "xx"         # example 'stm32f3xx'
+    if os.path.exists(os.path.join('./stm32cube', make_seriexx, 'CMakeLists.txt')):
+        # build new CMakeLists.txt
+        make_file = open(os.path.join('./stm32cube', make_seriexx, 'CMakeLists.txt'), 'r')
+        first_line = make_file.readline()         # this line is the copyright line
+        make_file.close()
+        os.remove(os.path.join('./stm32cube', make_seriexx, 'CMakeLists.txt'))
+    else:
+        first_line = '' 
+
+    print 'Create a new CMakeLists.txt file'
+
+    make_file = open(os.path.join('./stm32cube', make_seriexx, 'CMakeLists.txt'), 'w')
+    if first_line:
+        make_file.write(first_line)
+    make_file.write("# Copyright (c) 2019 STMicroelectronics.\n")
+    make_file.write("#\n")
+    make_file.write("# SPDX-License-Identifier: Apache-2.0\n")
+    make_file.write("\n")
+    make_Files = os.listdir(os.path.join('./stm32cube', make_seriexx, 'drivers/src'))
+    make_Files.sort()
+
+    make_file.write("zephyr_library_sources(soc/system_" + make_seriexx + ".c)\n")
+    make_file.write("zephyr_library_sources(drivers/src/" + make_seriexx + "_hal.c)\n")
+    make_file.write("zephyr_library_sources(drivers/src/" + make_seriexx + "_hal_rcc.c)\n")
+
+    for f in make_Files:
+        # also skipping  '_xxx_hal.c'
+        if 'template' in os.path.splitext(f)[0]:
+            continue
+        if '_hal_' in os.path.splitext(f)[0]:
+            make_file.write("zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_" +
+                            os.path.splitext(f)[0][(os.path.splitext(f)[0].index('_hal_')+5):].upper() +
+                            " " + os.path.join("drivers/src", f) + ")\n")
+        if '_ll_' in os.path.splitext(f)[0]:
+            make_file.write("zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_" +
+                            os.path.splitext(f)[0][(os.path.splitext(f)[0].index('_ll_')+4):].upper() +
+                            " " + os.path.join("drivers/src", f) + ")\n")
+
+    make_file.close()
+
+##############################################################################
+# copy the Release_Note.html from the original STM32Cube repo
+# into the current dir = ./module/stm32cube/stm32<serie>xx
+
+
+def release_note(make_serie):
+    if 'stm32' not in make_serie:
+        make_serie = 'stm32' + make_serie       # example 'stm32f3'
+
+    make_seriexx = make_serie.lower() + "xx"    # example 'stm32f3xx'
+    make_SERIE = make_serie.upper()             # example 'STM32F3'
+    make_SERIExx = make_SERIE + "xx"            # example 'STM32F3xx'
+
+    make_path = os.path.join(os.getenv("HOME"), "STM32Cube_repo/zephyr_module/stm32cube", make_seriexx)
+    make_repo = os.path.join(os.getenv("HOME"), "STM32Cube_repo", "STM32Cube" + make_SERIE[5:])
+    if os.path.exists(os.path.join(make_repo, 'Release_Notes.html')):
+        os.rename(os.path.join(make_repo, 'Release_Notes.html'),
+                  os.path.join(make_path, 'release_note.html'))
+
+##############################################################################
+# format the log error file after applying patch
+# return True if error where found
+# into the current dir = ./zephyr_module
+
+
+def log_file(make_serie):
+    if 'stm32' not in make_serie:
+        make_serie = 'stm32' + make_serie         # example 'stm32f3'
+    result = False
+    if os.path.exists('module.log'):
+        log_file = open('module.log', 'r')
+        log_file_new = open('module.new', 'w')
+        Lines = enumerate(log_file.read().splitlines())
+        log_file.close()
+        for LineItem in Lines:
+            if "error:" in LineItem[1].lower():
+                log_file_new.write("{0}\n".format(LineItem[1]))
+                result = True
+
+        log_file_new.flush()
+        log_file_new.close()
+        os.rename('module.new', 'module.log')
+
+    return result
+
+##############################################################################
+# clean the STM32Cube repo
+
+
+def cleanup(make_serie):
+    if 'stm32' not in make_serie:
+        make_serie = 'stm32' + make_serie       # example 'stm32f3'
+
+    make_seriexx = make_serie.lower() + "xx"    # example 'stm32f3xx'
+    make_SERIE = make_serie.upper()             # example 'STM32F3'
+    make_SERIExx = make_SERIE + "xx"            # example 'STM32F3xx'
+
+    os.chdir(os.path.join(os.getenv('HOME'), 'STM32Cube_repo'))
+    # 10.2) cleanup repo path
+    os.chdir("STM32Cube" + make_SERIE[5:])
+    os.system('git reset --hard HEAD &>/dev/null')
+    # 10.1) cleanup temp folder for zephyr module in STM32Cube repo
+    make_path = os.path.join(os.getenv('HOME'), 'STM32Cube_repo')
+    for root, dirs, files in os.walk(os.path.join(make_path, 'zephyr_module'), topdown=False):
+        for name in files:
+            os.remove(os.path.join(root, name))
+        for name in dirs:
+            os.rmdir(os.path.join(root, name))
+
+    os.rmdir(os.path.join(make_path, 'zephyr_module'))
+
+##############################################################################
+
+
+def reject(make_serie):
+    if 'stm32' not in make_serie:
+        make_serie = 'stm32' + make_serie       # example 'stm32f3'
+
+    make_seriexx = make_serie.lower() + "xx"    # example 'stm32f3xx'
+    make_SERIE = make_serie.upper()             # example 'STM32F3'
+    make_SERIExx = make_SERIE + "xx"            # example 'STM32F3xx'
+
+    make_path = os.path.join(os.getcwd(), 'stm32cube', make_seriexx)
+
+    for r, d, f in os.walk(make_path):
+        for file in f:
+            if '.rej' in file:
+                os.remove(os.path.join(r, file))
+
+
+##############################################################################
+
+
+def merge(make_serie):
+    if not os.path.exists('module.log'):
+        print "Error: no file to merge"
+        return
+
+    if os.path.exists('module.log'):
+        with open('module.log', 'r') as log_module:
+            log_files = enumerate(log_module.read().splitlines())
+            log_module.close()
+    for i, j in log_files:
+        log_file = j[21:21+j[21:].index(':')]
+        print 'Merging file : ' + log_file
+        merge_src = open(log_file, 'r')
+        lines = merge_src.read().splitlines()
+        if '<<<<<<< ours' not in [b for a, b in enumerate(lines)]:
+                merge_src.close()
+                continue
+        else:
+                merge_src.seek(0, 0)
+        merge_dest = open(log_file + '.new', 'w')
+        l = True
+        while l != '':
+                l = merge_src.readline()
+                if '<<<<<<< ours' in l:
+                        continue
+                if '=======' in l:
+                        l = merge_src.readline()
+                        while '>>>>>>> theirs' not in l:
+                                l = merge_src.readline()
+                if '>>>>>>> theirs' in l:
+                        continue
+                merge_dest.write(l)
+
+        merge_src.close()
+        merge_dest.close()
+        os.rename(log_file + '.new', log_file)

--- a/scripts/update_stm32_package.py
+++ b/scripts/update_stm32_package.py
@@ -1,0 +1,310 @@
+#!/usr/bin/python
+
+# Copyright (c) 2019 STMicroelectronics.
+# This script will update the stm32cube module for Zephyr
+# from the latest version on https://github.com/STMicroelectronics
+# get the patch between initial version and latest version
+# apply this patch on the zephyr module
+# usage : 'python update_stm32_package.py <stm32_serie>'
+
+import os
+import sys; sys.dont_write_bytecode = True    # do not generate pyc file
+import subprocess
+import time
+import make_stm32_module
+import shutil
+
+
+# execute with argument
+option_clean = True
+option_force = False
+module_serie = ''
+
+arg_names = ['command', 'a1', 'a2', 'a3']
+args = map(None, arg_names, sys.argv)
+args = {k: v for (k, v) in args}
+
+if args['a1']:
+    if 'stm32' in args['a1']:
+        module_serie = args['a1']
+    elif '-c' in args['a1']:
+        option_clean = False
+    elif '-f' in args['a1']:
+        option_force = True
+    elif '-h' in args['a1']:
+        print "usage: python update_stm32_package.py [--help] [-f] [-c] stm32XX\n"
+        print "       -c    will NOT clean the working repo"
+        print "       -f    will force the merge except .rej files"
+        print ""
+        sys.exit()
+    else:
+        print 'unknown option'
+if args['a2']:
+    if 'stm32' in args['a2']:
+        module_serie = args['a2']
+    elif '-c' in args['a2']:
+        option_clean = False
+    elif 'f' in args['a2']:
+        option_force = True
+    else:
+        print 'unknown option'
+if args['a3']:
+    if 'stm32' in args['a3']:
+        module_serie = args['a3']
+    elif '-c' in args['a3']:
+        option_clean = False
+    elif '-f' in args['a3']:
+        option_force = True
+    else:
+        print 'unknown option'
+
+if not module_serie or (not args['a1'] and not args['a2'] and not args['a3']):
+    print " Usage: " + sys.argv[0] + " stm32XX <Serie to create>"
+    print " --> example : python update_stm32_package.py stm32f3"
+    sys.exit()
+
+module_seriexx = module_serie + "xx"        # example 'stm32f3xx'
+module_SERIE = module_serie.upper()         # example 'STM32F3'
+module_SERIExx = module_SERIE + "xx"        # example 'STM32F3xx'
+
+# prepare the dir where to store the module repo
+if os.path.exists(os.getenv('ZEPHYR_BASE')):
+    os.chdir(os.getenv('ZEPHYR_BASE'))
+else:
+    print "Error: cannot find ./zephyr project"
+    sys.exit()
+
+# 1) clone full repo from github : get the repo STM32CubeXX
+repo_path = os.path.join(os.getenv('HOME'), 'STM32Cube_repo')
+if not os.path.exists(repo_path):
+    os.mkdir(repo_path)
+
+os.chdir(repo_path)
+repo_path = os.path.join(repo_path, 'STM32Cube' + module_SERIE[5:])
+print "Create repo in "+repo_path
+if not os.path.exists(repo_path):
+    git_cmd = 'git clone https://github.com/STMicroelectronics/STM32Cube' + module_SERIE[5:] + '.git'
+    while os.system(git_cmd) != 0:
+        time.sleep(2)
+    os.chdir(repo_path)
+else:
+    # if already exists, then just clean and fetch
+    os.chdir(repo_path)
+    os.system('git clean -fdx')
+    while os.system('git fetch') != 0:
+        time.sleep(2)
+    os.system('git reset --hard master')
+
+# get the latest version of cube: git tag -l to get a listing of all tags,
+# with the most recent one created being the last entry.
+git_cmd = 'git checkout master'
+os.system(git_cmd)
+version_tag = subprocess.check_output('git tag -l', shell=True).splitlines()
+latest_version = version_tag[-1]
+
+# 2) prepare a repo where to store module versions
+new_repo = os.path.join(os.getenv('HOME'), 'STM32Cube_repo', 'zephyr_module')
+if os.path.exists(new_repo):
+    shutil.rmtree(new_repo, ignore_errors=True)
+
+os.mkdir(new_repo)
+os.chdir(new_repo)
+os.system('git init')
+
+# 3) get the version of cube which is in the zephyr module
+os.chdir(os.path.join(os.getenv('ZEPHYR_BASE'), '../modules/hal/stm32/stm32cube',
+         module_seriexx))
+previous_version = subprocess.check_output('cat README | grep version | head -n1',
+                                           shell=True)[1:]
+previous_version = previous_version[previous_version.index('version ') + 8:-1]
+print "Version " + previous_version + " is the original version for " + os.getcwd()
+
+# 3.1) match previous version and list of existing tags which could be vx.y or x.y
+pos_version = [i for i, a in enumerate(version_tag) if previous_version in a]
+if pos_version:
+    previous_version = version_tag[pos_version[0]]
+else:
+    print "Error: cannot find version " + previous_version + " in STM32Cube_repo"
+    make_stm32_module.cleanup(module_serie)
+    sys.exit()
+
+# 3.2) do not process if versions are similar
+if (previous_version in latest_version) or (latest_version in previous_version):
+    print "Versions are identical: abandoned"
+    make_stm32_module.cleanup(module_serie)
+    sys.exit()
+
+# 4) build the module from this previous version
+# reset the STM32Cube repo to this previous version
+os.chdir(repo_path)
+git_cmd = 'git reset --hard ' + previous_version
+print git_cmd
+os.system(git_cmd)
+
+# build the zephyr module from the stm32cube
+previous_module = make_stm32_module.module(module_serie)
+print "Building module from STM32Cube_repo "+previous_version
+
+# populate the new repo with this previous_version
+os.renames(previous_module, os.path.join(new_repo, 'stm32cube', module_seriexx))
+print "Transfer previous module from " + previous_module + " to " + new_repo
+os.chdir(new_repo)
+
+git_cmd = 'git add -A stm32cube/' + module_seriexx + '/*'
+print git_cmd
+os.system(git_cmd)
+
+git_cmd = 'git commit -am \"module' + previous_version + '\"'
+print git_cmd
+os.system(git_cmd)
+
+git_cmd = 'git rebase --whitespace=fix HEAD~1'
+print "Remove remove trailing spaces: " + git_cmd
+os.system(git_cmd)
+
+# 5) build the module from the current version
+# clean-up the module
+os.chdir(new_repo)
+os.system('rm -rf ./stm32cube/*')
+
+# 5.1) and populate the new repo with this current zephyr module
+git_cmd = 'cp -rf ' + os.path.join(os.getenv('ZEPHYR_BASE'),
+                                   '../modules/hal/stm32/stm32cube',
+                                   module_seriexx) + ' ./stm32cube'
+print git_cmd
+os.system(git_cmd)
+
+# 5.2) commit this current version module
+git_cmd = 'git add * && git commit -am \"module\"'
+print git_cmd
+os.system(git_cmd)
+
+git_cmd = 'git rebase --whitespace=fix HEAD~1'
+print "Remove remove trailing spaces: " + git_cmd
+os.system(git_cmd)
+
+# 5.3) generate a patch for files and _hal.conf.h file in the module
+print 'Building patch from ' + previous_version + ' to current module'
+os.chdir(new_repo)
+if os.system('git diff --ignore-space-at-eol HEAD^ >> module.patch') == 0:
+    os.system('dos2unix module.patch')
+
+hal_conf = os.path.join('stm32cube', module_seriexx, 'drivers', 'include',
+                        module_seriexx + '_hal_conf.h')
+if os.path.exists(hal_conf):
+    git_cmd = 'git diff HEAD@{1} -- ' + hal_conf + ' >> hal_conf.patch'
+    os.system(git_cmd)
+    os.system('dos2unix hal_conf.patch')
+
+# 6) build the module from this latest version
+# reset the STM32Cube repo to this latest version
+os.chdir(repo_path)
+git_cmd = 'git reset --hard ' + latest_version
+print git_cmd
+os.system(git_cmd)
+
+# 6.1) include the commit id of this latest version
+git_cmd = 'git rev-parse HEAD'
+latest_commit = subprocess.check_output(git_cmd, shell=True)
+
+# 6.2) build the zephyr module from the stm32cube
+latest_module = make_stm32_module.module(module_serie)
+print "Building module from STM32Cube "+latest_version
+
+# 6.3) clean-up the module
+os.chdir(new_repo)
+git_cmd = 'rm -rf ' + './stm32cube/*'
+os.system(git_cmd)
+# and populate the new repo with this latest zephyr module
+os.renames(latest_module, os.path.join(new_repo, 'stm32cube', module_seriexx))
+# include README except CMakelists files from current module and update
+git_cmd = 'cp -rf ' + os.path.join(os.getenv('ZEPHYR_BASE'),
+                                   '../modules/hal/stm32/stm32cube',
+                                   module_seriexx,
+                                   'README') + os.path.join(
+                                   ' ./stm32cube',
+                                   module_seriexx,
+                                   'README')
+print git_cmd
+os.system(git_cmd)
+git_cmd = 'cp -rf ' + os.path.join(os.getenv('ZEPHYR_BASE'),
+                                   '../modules/hal/stm32/stm32cube',
+                                   module_seriexx,
+                                   'CMakeLists.txt') + os.path.join(
+                                   ' ./stm32cube',
+                                   module_seriexx,
+                                   'CMakeLists.txt')
+print git_cmd
+os.system(git_cmd)
+
+# 6.4) update README and CMakeList and copy release note
+make_stm32_module.readme(module_serie, latest_version, latest_commit)
+make_stm32_module.makelist(module_serie)
+make_stm32_module.release_note(module_serie)
+
+# 6.5) apply previous patch on hal_conf.h file
+if os.path.exists('hal_conf.patch'):
+    git_cmd = 'git apply --recount --3way ./hal_conf.patch'
+    os.system(git_cmd + ' &>/dev/null')
+    os.remove('hal_conf.patch')
+
+# 6.6) commit files except log or patch files
+git_cmd = 'git add * && git reset -- *.patch && git reset -- *.log'
+print git_cmd
+os.system(git_cmd)
+git_cmd = 'git commit -am \"module' + latest_version + '\"'
+print git_cmd
+os.system(git_cmd)
+
+# 6.7) remove trailing spaces
+git_cmd = 'git rebase --whitespace=fix HEAD~1'
+print "Remove remove trailing spaces: " + git_cmd
+os.system(git_cmd)
+
+# 6.8) generate a patch for each file in the module
+if os.system('git diff  HEAD^ >> new_version.patch') == 0:
+    os.system('dos2unix new_version.patch')
+
+# 7) build the patch : in the zephyr module repo
+print 'Building zephyr module from ' + previous_version + ' to ' + latest_version
+module_path = os.path.join(os.getenv('ZEPHYR_BASE'), '../modules/hal/stm32')
+os.chdir(module_path)
+
+# 7.1) copy from new_repo
+git_cmd = 'rm -rf ' + os.path.join('stm32cube', module_seriexx)
+os.system(git_cmd)
+git_cmd = 'cp -r ' + os.path.join(new_repo, 'stm32cube', module_seriexx) + ' ' + os.path.join('stm32cube', module_seriexx)
+os.system(git_cmd)
+
+# 7.2) apply patch from new repo
+module_log = "module_" + module_serie + ".log"
+git_cmd = 'git apply --recount --reject ' + os.path.join(new_repo, 'module.patch') + ' &>' + module_log
+if os.system(git_cmd):
+    print "Error when applying patch to zephyr module: see "+os.path.join(module_path, module_log)
+else:
+    option_force = True
+ 
+# 7.3) add files but do not commit
+os.system('git add * && git reset -- *.patch && git reset -- *.log && git reset -- *.rej')
+print "README file : --> please check that the Patch list is still valid"
+
+# 7.5) merge & commit if needed
+if option_force:
+    print "Force commit module "
+    # to clean the .rej files, use: make_stm32_module.reject(module_serie)
+    git_cmd = 'git commit -asm \"stm32cube: update ' + module_serie + ' to version ' + latest_version.upper() + '\n'
+    git_cmd = git_cmd + '\n   Update Cube version for ' + module_SERIExx + ' series'
+    git_cmd = git_cmd + '\n   on https://github.com/STMicroelectronics'
+    git_cmd = git_cmd + '\n   from version ' + previous_version
+    git_cmd = git_cmd + '\n   to version ' + latest_version + '\"'
+    print git_cmd
+    update_list = subprocess.check_output(git_cmd, shell=True).splitlines()
+
+# 8) end
+if option_clean:
+    make_stm32_module.cleanup(module_serie)
+
+os.chdir(repo_path)
+os.system('git reset --hard HEAD &>/dev/null')
+
+print "Done "


### PR DESCRIPTION
For stm32 series, get the version tree found on
https://github.com/STMicroelectronics/STM32Cube
and apply patches to update module to the latest version

run with `$ python ./scripts/update_stm32_package.py stm32xx`

Signed-off-by: Francois Ramu <francois.ramu@st.com>