### PR TITLE
stm32cube: stm32g4xx: wrong clock setup

### DIFF
--- a/stm32cube/stm32g4xx/README
+++ b/stm32cube/stm32g4xx/README
@@ -35,4 +35,10 @@ License Link:
    https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
-   none
+
+   *stm32g4xx: wrong clock setup
+    In case the actual value is AHB prescaler 1, it must be set, 
+    after setting the AHB prescaler to 2.
+    Impacted files:
+     drivers/src/stm32g4xx_ll_utils.c
+    ST Bug tracker ID: 78880

--- a/stm32cube/stm32g4xx/drivers/src/stm32g4xx_ll_utils.c
+++ b/stm32cube/stm32g4xx/drivers/src/stm32g4xx_ll_utils.c
@@ -325,7 +325,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
     status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
 
     /* Apply definitive AHB prescaler value if necessary */
-    if((status == SUCCESS) && (hpre != 0U))
+    if((status == SUCCESS) && (hpre == LL_RCC_SYSCLK_DIV_1))
     {
       UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
       LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);
@@ -416,7 +416,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
     status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
 
     /* Apply definitive AHB prescaler value if necessary */
-    if((status == SUCCESS) && (hpre != 0U))
+    if((status == SUCCESS) && (hpre == LL_RCC_SYSCLK_DIV_1))
     {
       UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
       LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);


### PR DESCRIPTION
When configuring the PLL > 80MHz, an intermediate step is needed 
with AHB prescaler set to 2 before setting the actual value.
In case the actual value is AHB prescaler 1, it must be set, though.

This will fix https://github.com/zephyrproject-rtos/zephyr/issues/21715

Signed-off-by: Francois Ramu <francois.ramu@st.com>