### PR TITLE
stm32cube: stm32g4xx: Fix SystemCoreClock value > 80MHz

### DIFF
--- a/stm32cube/stm32g4xx/README
+++ b/stm32cube/stm32g4xx/README
@@ -42,3 +42,8 @@ Patch List:
     Impacted files:
      drivers/src/stm32g4xx_ll_utils.c
     ST Bug tracker ID: 78880
+   *stm32g4xx: system clock value not update when > 80MHz
+    After AHB prescaler to 2 clock value is updated but not
+    once returned to 1 the clock value needs updated.
+    Impacted files:
+      drivers/src/stm32g4xx_ll_utils.c

--- a/stm32cube/stm32g4xx/drivers/src/stm32g4xx_ll_utils.c
+++ b/stm32cube/stm32g4xx/drivers/src/stm32g4xx_ll_utils.c
@@ -329,6 +329,9 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
     {
       UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
       LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);
+
+      /* Enable PLL and switch system clock to PLL */
+      status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
     }
   }
   else
@@ -420,6 +423,9 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
     {
       UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
       LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);
+
+      /* Enable PLL and switch system clock to PLL */
+      status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
     }
   }
   else


### PR DESCRIPTION
SystemCoreClock value should be updated after AHB prescale
is set back to 1.

Signed-off-by: Richard Osterloh <richard.osterloh@gmail.com>