### PR TITLE
stm32cube: stm32g4x and stm32l4Rx / stm32l4Sx: Fix SystemCoreClock value > 80MHz

### DIFF
--- a/stm32cube/stm32g4xx/README
+++ b/stm32cube/stm32g4xx/README
@@ -42,3 +42,8 @@ Patch List:
     Impacted files:
      drivers/src/stm32g4xx_ll_utils.c
     ST Bug tracker ID: 78880
+   *stm32g4xx: system clock value not update when > 80MHz
+    After AHB prescaler to 2 clock value is updated but not
+    once returned to 1 the clock value needs updated.
+    Impacted files:
+      drivers/src/stm32g4xx_ll_utils.c

--- a/stm32cube/stm32g4xx/drivers/src/stm32g4xx_ll_utils.c
+++ b/stm32cube/stm32g4xx/drivers/src/stm32g4xx_ll_utils.c
@@ -329,6 +329,9 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
     {
       UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
       LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);
+
+      /* Enable PLL and switch system clock to PLL */
+      status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
     }
   }
   else
@@ -420,6 +423,9 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
     {
       UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
       LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);
+
+      /* Enable PLL and switch system clock to PLL */
+      status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
     }
   }
   else

--- a/stm32cube/stm32l4xx/README
+++ b/stm32cube/stm32l4xx/README
@@ -43,3 +43,10 @@ Patch List:
     Impacted files:
      drivers/include/stm32l4xx_ll_exti.h
     ST Bug tracker ID: 55275
+
+   *stm32l4xx: wrong clock setup
+    In case the actual value is AHB prescaler 1, it must be set, 
+    after setting the AHB prescaler to 2.
+    Impacted files:
+     drivers/src/stm32l4xx_ll_utils.c
+    ST Bug tracker ID: 78880

--- a/stm32cube/stm32l4xx/drivers/src/stm32l4xx_ll_utils.c
+++ b/stm32cube/stm32l4xx/drivers/src/stm32l4xx_ll_utils.c
@@ -390,10 +390,11 @@ ErrorStatus LL_PLL_ConfigSystemClock_MSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
 
 #if defined(STM32L4R5xx) || defined(STM32L4R7xx) || defined(STM32L4R9xx) || defined(STM32L4S5xx) || defined(STM32L4S7xx) || defined(STM32L4S9xx)
       /* Apply definitive AHB prescaler value if necessary */
-      if((status == SUCCESS) && (hpre != 0U))
+      if((status == SUCCESS) && (hpre == LL_RCC_SYSCLK_DIV_1))
       {
         UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
         LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);
+        status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
       }
 #endif
     }
@@ -468,10 +469,11 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
 
 #if defined(STM32L4R5xx) || defined(STM32L4R7xx) || defined(STM32L4R9xx) || defined(STM32L4S5xx) || defined(STM32L4S7xx) || defined(STM32L4S9xx)
     /* Apply definitive AHB prescaler value if necessary */
-    if((status == SUCCESS) && (hpre != 0U))
+    if((status == SUCCESS) && (hpre == LL_RCC_SYSCLK_DIV_1))
     {
       UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
       LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);
+      status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
     }
 #endif
   }
@@ -564,10 +566,11 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 
 #if defined(STM32L4R5xx) || defined(STM32L4R7xx) || defined(STM32L4R9xx) || defined(STM32L4S5xx) || defined(STM32L4S7xx) || defined(STM32L4S9xx)
     /* Apply definitive AHB prescaler value if necessary */
-    if((status == SUCCESS) && (hpre != 0U))
+    if((status == SUCCESS) && (hpre == LL_RCC_SYSCLK_DIV_1))
     {
       UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
       LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);
+      status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
     }
 #endif
   }


### PR DESCRIPTION
set the AHB prescaler with correct value in case the pll
requires LL_RCC_SYSCLK_DIV_1 for HSE and HSI or MSI

This PR includes the https://github.com/zephyrproject-rtos/hal_stm32/pull/36
and applies the same fix to the STM32L4Rx and STM32L4Sx series

Signed-off-by: Francois Ramu <francois.ramu@st.com>