### PR TITLE
hal_stm32: rename HAS_STLIB in HAS_STM32LIB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_subdirectory_ifdef(CONFIG_HAS_STM32CUBE stm32cube)
-add_subdirectory_ifdef(CONFIG_HAS_STLIB lib)
+add_subdirectory_ifdef(CONFIG_HAS_STM32LIB lib)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_HAS_STLIB)
+if(CONFIG_HAS_STM32LIB)
   if(CONFIG_BT_STM32_IPM)
     zephyr_include_directories(stm32wb/hci)
     zephyr_sources(stm32wb/hci/shci.c)


### PR DESCRIPTION
Both modules ST and STM32 use the same HAS_STLIB Kconfig symbol.
This is not coherent, so rename the one used in stm32 module
as HAS_STM32LIB

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>