### PR TITLE
stm32l0xx: Add stm32l0xx_ll_usb to CMakeLists

### DIFF
--- a/stm32cube/stm32l0xx/CMakeLists.txt
+++ b/stm32cube/stm32l0xx/CMakeLists.txt
@@ -97,3 +97,4 @@ zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_SWPMI drivers/src/stm32l0xx_ll_
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_TIM drivers/src/stm32l0xx_ll_tim.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_USART drivers/src/stm32l0xx_ll_usart.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_UTILS drivers/src/stm32l0xx_ll_utils.c)
+zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_USB drivers/src/stm32l0xx_ll_usb.c)


### PR DESCRIPTION
Some STM32L0 SoCs contain a USB device controller. Add the LL USB HAL to enable USB support in Zephyr.
