### PR TITLE
stm32cube: extend public SetFlashLatency API to all families

### DIFF
--- a/stm32cube/stm32f0xx/README
+++ b/stm32cube/stm32f0xx/README
@@ -35,4 +35,13 @@ License Link:
    https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
+
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5. The private function has been made public.
+    Impacted files:
+     drivers/include/stm32f0xx_ll_utils.h
+     drivers/src/stm32f0xx_ll_utils.c
+    ST Bug tracker ID: 76117
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f0xx/drivers/include/stm32f0xx_ll_utils.h
+++ b/stm32cube/stm32f0xx/drivers/include/stm32f0xx_ll_utils.h
@@ -245,6 +245,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI48(LL_UTILS_PLLInitTypeDef *UTILS_PLLIni
 #endif /*RCC_CFGR_SW_HSI48*/
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t Frequency);
 
 /**
   * @}

--- a/stm32cube/stm32f0xx/drivers/src/stm32f0xx_ll_utils.c
+++ b/stm32cube/stm32f0xx/drivers/src/stm32f0xx_ll_utils.c
@@ -116,9 +116,6 @@
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
                                                LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-#if defined(FLASH_ACR_LATENCY)
-static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency);
-#endif /* FLASH_ACR_LATENCY */
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 /**
@@ -426,17 +423,6 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 }
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup UTILS_LL_Private_Functions
-  * @{
-  */
-/**
   * @brief  Update number of Flash wait states in line with new frequency and current
             voltage range.
   * @param  Frequency  SYSCLK frequency
@@ -445,7 +431,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   *          - ERROR: Latency cannot be modified
   */
 #if defined(FLASH_ACR_LATENCY)
-static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
+ErrorStatus LL_SetFlashLatency(uint32_t Frequency)
 {
   ErrorStatus status = SUCCESS;
 
@@ -478,6 +464,17 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
 }
 #endif /* FLASH_ACR_LATENCY */
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup UTILS_LL_Private_Functions
+  * @{
+  */
 /**
   * @brief  Function to check that PLL can be modified
   * @param  PLL_InputFrequency  PLL input frequency (in Hz)
@@ -549,7 +546,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (sysclk_frequency_current < SYSCLK_Frequency)
   {
     /* Set FLASH latency to highest latency */
-    status = UTILS_SetFlashLatency(SYSCLK_Frequency);
+    status = LL_SetFlashLatency(SYSCLK_Frequency);
   }
 
   /* Update system clock configuration */
@@ -578,7 +575,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (sysclk_frequency_current > SYSCLK_Frequency)
   {
     /* Set FLASH latency to lowest latency */
-    status = UTILS_SetFlashLatency(SYSCLK_Frequency);
+    status = LL_SetFlashLatency(SYSCLK_Frequency);
   }
 
   /* Update SystemCoreClock variable */

--- a/stm32cube/stm32f1xx/README
+++ b/stm32cube/stm32f1xx/README
@@ -36,6 +36,14 @@ License Link:
 
 Patch List:
 
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5. The private function has been made public.
+    Impacted files:
+     drivers/include/stm32f1xx_ll_utils.h
+     drivers/src/stm32f1xx_ll_utils.c
+    ST Bug tracker ID: 76118
+
    *Changes from official delivery:
     -dos2unix applied
     -trailing white spaces removed

--- a/stm32cube/stm32f1xx/drivers/include/stm32f1xx_ll_utils.h
+++ b/stm32cube/stm32f1xx/drivers/include/stm32f1xx_ll_utils.h
@@ -240,6 +240,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t Frequency);
 
 /**
   * @}

--- a/stm32cube/stm32f1xx/drivers/src/stm32f1xx_ll_utils.c
+++ b/stm32cube/stm32f1xx/drivers/src/stm32f1xx_ll_utils.c
@@ -140,9 +140,6 @@
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
                                                LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-#if defined(FLASH_ACR_LATENCY)
-static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency);
-#endif /* FLASH_ACR_LATENCY */
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 /**
@@ -383,17 +380,6 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 }
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup UTILS_LL_Private_Functions
-  * @{
-  */
-/**
   * @brief  Update number of Flash wait states in line with new frequency and current
             voltage range.
   * @param  Frequency  SYSCLK frequency
@@ -402,7 +388,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   *          - ERROR: Latency cannot be modified
   */
 #if defined(FLASH_ACR_LATENCY)
-static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
+ErrorStatus LL_SetFlashLatency(uint32_t Frequency)
 {
   ErrorStatus status = SUCCESS;
 
@@ -443,6 +429,17 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
 }
 #endif /* FLASH_ACR_LATENCY */
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup UTILS_LL_Private_Functions
+  * @{
+  */
 /**
   * @brief  Function to check that PLL can be modified
   * @param  PLL_InputFrequency  PLL input frequency (in Hz)
@@ -535,7 +532,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (sysclk_frequency_current < SYSCLK_Frequency)
   {
     /* Set FLASH latency to highest latency */
-    status = UTILS_SetFlashLatency(SYSCLK_Frequency);
+    status = LL_SetFlashLatency(SYSCLK_Frequency);
   }
 #endif /* FLASH_ACR_LATENCY */
 
@@ -578,7 +575,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (sysclk_frequency_current > SYSCLK_Frequency)
   {
     /* Set FLASH latency to lowest latency */
-    status = UTILS_SetFlashLatency(SYSCLK_Frequency);
+    status = LL_SetFlashLatency(SYSCLK_Frequency);
   }
 #endif /* FLASH_ACR_LATENCY */
 

--- a/stm32cube/stm32f2xx/README
+++ b/stm32cube/stm32f2xx/README
@@ -35,6 +35,15 @@ License Link:
    https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
+
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5. The private function has been made public.
+    Impacted files:
+     drivers/include/stm32f2xx_ll_utils.h
+     drivers/src/stm32f2xx_ll_utils.c
+    ST Bug tracker ID: 76119
+
    *Disable i2c HAL
      Due to conflict with zephyr i2c.h (I2C_SPEED_STANDARD and I2C_SPEED_FAST
      redefinition), deactivate STM32Cube I2C HAL. This raises no issue since

--- a/stm32cube/stm32f2xx/drivers/include/stm32f2xx_ll_utils.h
+++ b/stm32cube/stm32f2xx/drivers/include/stm32f2xx_ll_utils.h
@@ -246,6 +246,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency);
 
 /**
   * @}

--- a/stm32cube/stm32f2xx/drivers/src/stm32f2xx_ll_utils.c
+++ b/stm32cube/stm32f2xx/drivers/src/stm32f2xx_ll_utils.c
@@ -176,7 +176,6 @@
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
                                                LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency);
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 /**
@@ -424,17 +423,6 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 }
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup UTILS_LL_Private_Functions
-  * @{
-  */
-/**
   * @brief  Update number of Flash wait states in line with new frequency and current
             voltage range.
   * @param  HCLK_Frequency  HCLK frequency
@@ -442,7 +430,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   *          - SUCCESS: Latency has been modified
   *          - ERROR: Latency cannot be modified
   */
-static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency)
+ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency)
 {
   ErrorStatus status = SUCCESS;
 
@@ -487,6 +475,17 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency)
   return status;
 }
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup UTILS_LL_Private_Functions
+  * @{
+  */
 /**
   * @brief  Function to check that PLL can be modified
   * @param  PLL_InputFrequency  PLL input frequency (in Hz)
@@ -570,7 +569,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if(SystemCoreClock < hclk_frequency)
   {
     /* Set FLASH latency to highest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update system clock configuration */
@@ -600,7 +599,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if(SystemCoreClock > hclk_frequency)
   {
     /* Set FLASH latency to lowest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update SystemCoreClock variable */

--- a/stm32cube/stm32f3xx/README
+++ b/stm32cube/stm32f3xx/README
@@ -36,4 +36,12 @@ License Link:
 
 Patch List:
 
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5. The private function has been made public.
+    Impacted files:
+     drivers/include/stm32f3xx_ll_utils.h
+     drivers/src/stm32f3xx_ll_utils.c
+    ST Bug tracker ID: 76120
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f3xx/drivers/include/stm32f3xx_ll_utils.h
+++ b/stm32cube/stm32f3xx/drivers/include/stm32f3xx_ll_utils.h
@@ -253,6 +253,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t Frequency);
 
 /**
   * @}

--- a/stm32cube/stm32f3xx/drivers/src/stm32f3xx_ll_utils.c
+++ b/stm32cube/stm32f3xx/drivers/src/stm32f3xx_ll_utils.c
@@ -122,9 +122,6 @@
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
                                                LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-#if defined(FLASH_ACR_LATENCY)
-static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency);
-#endif /* FLASH_ACR_LATENCY */
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 /**
@@ -378,17 +375,6 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 }
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup UTILS_LL_Private_Functions
-  * @{
-  */
-/**
   * @brief  Update number of Flash wait states in line with new frequency and current
             voltage range.
   * @param  Frequency  SYSCLK frequency
@@ -397,7 +383,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   *          - ERROR: Latency cannot be modified
   */
 #if defined(FLASH_ACR_LATENCY)
-static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
+ErrorStatus LL_SetFlashLatency(uint32_t Frequency)
 {
   ErrorStatus status = SUCCESS;
 
@@ -438,6 +424,17 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
 }
 #endif /* FLASH_ACR_LATENCY */
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup UTILS_LL_Private_Functions
+  * @{
+  */
 /**
   * @brief  Function to check that PLL can be modified
   * @param  PLL_InputFrequency  PLL input frequency (in Hz)
@@ -510,7 +507,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (sysclk_frequency_current < SYSCLK_Frequency)
   {
     /* Set FLASH latency to highest latency */
-    status = UTILS_SetFlashLatency(SYSCLK_Frequency);
+    status = LL_SetFlashLatency(SYSCLK_Frequency);
   }
 
   /* Update system clock configuration */
@@ -540,7 +537,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (sysclk_frequency_current > SYSCLK_Frequency)
   {
     /* Set FLASH latency to lowest latency */
-    status = UTILS_SetFlashLatency(SYSCLK_Frequency);
+    status = LL_SetFlashLatency(SYSCLK_Frequency);
   }
 
   /* Update SystemCoreClock variable */

--- a/stm32cube/stm32f4xx/README
+++ b/stm32cube/stm32f4xx/README
@@ -37,6 +37,14 @@ License Link:
 Patch List:
    See release_note.html from STM32Cube
 
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5. The private function has been made public.
+    Impacted files:
+     drivers/include/stm32f4xx_ll_utils.h
+     drivers/src/stm32f4xx_ll_utils.c
+    ST Bug tracker ID: 76121
+
    *Disable i2c HAL
      Due to conflict with zephyr i2c.h (I2C_SPEED_STANDARD and I2C_SPEED_FAST
      redefinition), deactivate STM32Cube I2C HAL. This raises no issue since

--- a/stm32cube/stm32f4xx/drivers/include/stm32f4xx_ll_utils.h
+++ b/stm32cube/stm32f4xx/drivers/include/stm32f4xx_ll_utils.h
@@ -283,6 +283,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency);
 
 /**
   * @}

--- a/stm32cube/stm32f4xx/drivers/src/stm32f4xx_ll_utils.c
+++ b/stm32cube/stm32f4xx/drivers/src/stm32f4xx_ll_utils.c
@@ -232,7 +232,6 @@
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
                                                LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency);
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 /**
@@ -455,17 +454,6 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 }
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup UTILS_LL_Private_Functions
-  * @{
-  */
-/**
   * @brief  Update number of Flash wait states in line with new frequency and current
             voltage range.
   * @note   This Function support ONLY devices with supply voltage (voltage range) between 2.7V and 3.6V
@@ -474,7 +462,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   *          - SUCCESS: Latency has been modified
   *          - ERROR: Latency cannot be modified
   */
-static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency)
+ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency)
 {
   ErrorStatus status = SUCCESS;
 
@@ -591,6 +579,17 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency)
 }
 
 /**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup UTILS_LL_Private_Functions
+  * @{
+  */
+/**
   * @brief  Function to check that PLL can be modified
   * @param  PLL_InputFrequency  PLL input frequency (in Hz)
   * @param  UTILS_PLLInitStruct pointer to a @ref LL_UTILS_PLLInitTypeDef structure that contains
@@ -683,7 +682,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if(SystemCoreClock < hclk_frequency)
   {
     /* Set FLASH latency to highest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update system clock configuration */
@@ -713,7 +712,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if(SystemCoreClock > hclk_frequency)
   {
     /* Set FLASH latency to lowest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update SystemCoreClock variable */

--- a/stm32cube/stm32f7xx/README
+++ b/stm32cube/stm32f7xx/README
@@ -37,6 +37,14 @@ License Link:
 Patch List:
    See release_note.html from STM32Cube
 
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5. The private function has been made public.
+    Impacted files:
+     drivers/include/stm32f7xx_ll_utils.h
+     drivers/src/stm32f7xx_ll_utils.c
+    ST Bug tracker ID: 76122
+
    *Fix LL_EXTI_LINE_18 and LL_EXTI_LINE_20 declarations
      LL_EXTI_LINE_18 and LL_EXTI_LINE_20 are declared in stm32f7xx_hal_pcd.h
      and in stm32f7xx_ll_exti.h which generates warnings. Set #ifndef

--- a/stm32cube/stm32f7xx/drivers/include/stm32f7xx_ll_utils.h
+++ b/stm32cube/stm32f7xx/drivers/include/stm32f7xx_ll_utils.h
@@ -279,6 +279,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency);
 
 /**
   * @}

--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_ll_utils.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_ll_utils.c
@@ -193,7 +193,6 @@
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
                                                LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency);
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 /**
@@ -444,17 +443,6 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 }
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup UTILS_LL_Private_Functions
-  * @{
-  */
-/**
   * @brief  Update number of Flash wait states in line with new frequency and current
             voltage range.
   * @note   This Function support ONLY devices with supply voltage (voltage range) between 2.7V and 3.6V
@@ -463,7 +451,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   *          - SUCCESS: Latency has been modified
   *          - ERROR: Latency cannot be modified
   */
-static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency)
+ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency)
 {
   ErrorStatus status = SUCCESS;
 
@@ -594,6 +582,17 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency)
 }
 
 /**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup UTILS_LL_Private_Functions
+  * @{
+  */
+/**
   * @brief  Function to check that PLL can be modified
   * @param  PLL_InputFrequency  PLL input frequency (in Hz)
   * @param  UTILS_PLLInitStruct pointer to a @ref LL_UTILS_PLLInitTypeDef structure that contains
@@ -682,7 +681,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if(SystemCoreClock < hclk_frequency)
   {
     /* Set FLASH latency to highest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update system clock configuration */
@@ -712,7 +711,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if(SystemCoreClock > hclk_frequency)
   {
     /* Set FLASH latency to lowest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update SystemCoreClock variable */

--- a/stm32cube/stm32g0xx/README
+++ b/stm32cube/stm32g0xx/README
@@ -35,4 +35,13 @@ License Link:
    https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
+
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5. The private function has been made public.
+    Impacted files:
+     drivers/include/stm32g0xx_ll_utils.h
+     drivers/src/stm32g0xx_ll_utils.c
+    ST Bug tracker ID: 76033
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_utils.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_utils.h
@@ -272,6 +272,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency);
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_utils.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_utils.c
@@ -128,7 +128,6 @@
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
                                                LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency);
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 /**
@@ -368,17 +367,6 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 }
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup UTILS_LL_Private_Functions
-  * @{
-  */
-/**
   * @brief  Update number of Flash wait states in line with new frequency and current
             voltage range.
   * @param  HCLK_Frequency  HCLK frequency
@@ -386,7 +374,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   *          - SUCCESS: Latency has been modified
   *          - ERROR: Latency cannot be modified
   */
-static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency)
+ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency)
 {
   ErrorStatus status = SUCCESS;
 
@@ -426,6 +414,17 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK_Frequency)
   return status;
 }
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup UTILS_LL_Private_Functions
+  * @{
+  */
 /**
   * @brief  Function to check that PLL can be modified
   * @param  PLL_InputFrequency  PLL input frequency (in Hz)
@@ -502,7 +501,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (SystemCoreClock < hclk_frequency)
   {
     /* Set FLASH latency to highest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update system clock configuration */
@@ -532,7 +531,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (SystemCoreClock > hclk_frequency)
   {
     /* Set FLASH latency to lowest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update SystemCoreClock variable */

--- a/stm32cube/stm32h7xx/README
+++ b/stm32cube/stm32h7xx/README
@@ -35,4 +35,13 @@ License Link:
    https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
+
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5.
+    Impacted files:
+     drivers/include/stm32h7xx_ll_utils.h
+     drivers/src/stm32h7xx_ll_utils.c
+    ST Bug tracker ID: XXXXX
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_utils.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_utils.h
@@ -355,6 +355,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency,
                                          uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct,
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t HCLKFrequency);
 
 /**
   * @}

--- a/stm32cube/stm32h7xx/drivers/src/stm32h7xx_ll_utils.c
+++ b/stm32cube/stm32h7xx/drivers/src/stm32h7xx_ll_utils.c
@@ -605,6 +605,28 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 }
 
 /**
+  * @brief  Update number of Flash wait states in line with new frequency and current
+            voltage range.
+  * @param  HCLKFrequency  HCLK frequency
+  * @retval An ErrorStatus enumeration value:
+  *          - SUCCESS: Latency has been modified
+  *          - ERROR: Latency cannot be modified
+  */
+ErrorStatus LL_SetFlashLatency(uint32_t HCLKFrequency)
+{
+  ErrorStatus status;
+  uint32_t latency;
+
+  status = UTILS_CalculateFlashLatency(HCLKFrequency, &latency);
+
+  if(status == SUCCESS)
+  {
+    status = UTILS_SetFlashLatency(latency);
+  }
+  return status;
+}
+
+/**
   * @}
   */
 

--- a/stm32cube/stm32l0xx/README
+++ b/stm32cube/stm32l0xx/README
@@ -36,6 +36,14 @@ License Link:
 
 Patch List:
 
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5. The private function has been made public.
+    Impacted files:
+     drivers/include/stm32l0xx_ll_utils.h
+     drivers/src/stm32l0xx_ll_utils.c
+    ST Bug tracker ID: 76125
+
     *Fix warnings for extraneous parentheses
       Using clang 7.0.1, if ((htim->State == HAL_TIM_STATE_BUSY))
       generates warnings.  Remove the extra parentheses

--- a/stm32cube/stm32l0xx/drivers/include/stm32l0xx_ll_utils.h
+++ b/stm32cube/stm32l0xx/drivers/include/stm32l0xx_ll_utils.h
@@ -242,6 +242,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t Frequency);
 
 /**
   * @}

--- a/stm32cube/stm32l0xx/drivers/src/stm32l0xx_ll_utils.c
+++ b/stm32cube/stm32l0xx/drivers/src/stm32l0xx_ll_utils.c
@@ -121,7 +121,6 @@
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
                                                LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency);
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 /**
@@ -359,17 +358,6 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 }
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup UTILS_LL_Private_Functions
-  * @{
-  */
-/**
   * @brief  Update number of Flash wait states in line with new frequency and current
             voltage range.
   * @param  Frequency  HCLK frequency
@@ -377,7 +365,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   *          - SUCCESS: Latency has been modified
   *          - ERROR: Latency cannot be modified
   */
-static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
+ErrorStatus LL_SetFlashLatency(uint32_t Frequency)
 {
   ErrorStatus status = SUCCESS;
 
@@ -430,6 +418,17 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
   return status;
 }
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup UTILS_LL_Private_Functions
+  * @{
+  */
 /**
   * @brief  Function to check that PLL can be modified
   * @param  PLL_InputFrequency  PLL input frequency (in Hz)
@@ -507,7 +506,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (SystemCoreClock < hclk_frequency)
   {
     /* Set FLASH latency to highest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update system clock configuration */
@@ -537,7 +536,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (SystemCoreClock > hclk_frequency)
   {
     /* Set FLASH latency to lowest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update SystemCoreClock variable */

--- a/stm32cube/stm32l1xx/README
+++ b/stm32cube/stm32l1xx/README
@@ -36,6 +36,14 @@ License Link:
 
 Patch List:
 
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5. The private function has been made public.
+    Impacted files:
+     drivers/include/stm32l1xx_ll_utils.h
+     drivers/src/stm32l1xx_ll_utils.c
+    ST Bug tracker ID: 76126
+
     *ext/hal/st/stm32cube/stm32l1xx: rename SVC_IRQn -> SVCall_IRQn
 
      SVCall_IRQn is used as enum value for SV Call Interrupt for Cortex-M

--- a/stm32cube/stm32l1xx/drivers/include/stm32l1xx_ll_utils.h
+++ b/stm32cube/stm32l1xx/drivers/include/stm32l1xx_ll_utils.h
@@ -244,6 +244,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t Frequency);
 
 /**
   * @}

--- a/stm32cube/stm32l1xx/drivers/src/stm32l1xx_ll_utils.c
+++ b/stm32cube/stm32l1xx/drivers/src/stm32l1xx_ll_utils.c
@@ -121,9 +121,6 @@
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
                                                LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-#if defined(FLASH_ACR_LATENCY)
-static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency);
-#endif /* FLASH_ACR_LATENCY */
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 /**
@@ -370,17 +367,6 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
 }
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup UTILS_LL_Private_Functions
-  * @{
-  */
-/**
   * @brief  Update number of Flash wait states in line with new frequency and current
             voltage range.
   * @param  Frequency  HCLK frequency
@@ -389,7 +375,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   *          - ERROR: Latency cannot be modified
   */
 #if defined(FLASH_ACR_LATENCY)
-static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
+ErrorStatus LL_SetFlashLatency(uint32_t Frequency)
 {
   ErrorStatus status = SUCCESS;
 
@@ -449,6 +435,17 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
 }
 #endif /* FLASH_ACR_LATENCY */
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup UTILS_LL_Private_Functions
+  * @{
+  */
 /**
   * @brief  Function to check that PLL can be modified
   * @param  PLL_InputFrequency  PLL input frequency (in Hz)
@@ -525,7 +522,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (SystemCoreClock < hclk_frequency)
   {
     /* Set FLASH latency to highest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update system clock configuration */
@@ -555,7 +552,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (SystemCoreClock > hclk_frequency)
   {
     /* Set FLASH latency to lowest latency */
-    status = UTILS_SetFlashLatency(hclk_frequency);
+    status = LL_SetFlashLatency(hclk_frequency);
   }
 
   /* Update SystemCoreClock variable */

--- a/stm32cube/stm32wbxx/README
+++ b/stm32cube/stm32wbxx/README
@@ -35,4 +35,13 @@ License Link:
    https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
+
+    *Extend public SetFlashLatency API to all families
+     The LL_SetFlashLatency public API is now defined for families
+     beyond G4, L4 and L5. The private function has been made public.
+    Impacted files:
+     drivers/include/stm32wbxx_ll_utils.h
+     drivers/src/stm32wbxx_ll_utils.c
+    ST Bug tracker ID: 76130
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32wbxx/drivers/include/stm32wbxx_ll_utils.h
+++ b/stm32cube/stm32wbxx/drivers/include/stm32wbxx_ll_utils.h
@@ -292,6 +292,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+ErrorStatus LL_SetFlashLatency(uint32_t HCLK4_Frequency);
 
 /**
   * @}

--- a/stm32cube/stm32wbxx/drivers/src/stm32wbxx_ll_utils.c
+++ b/stm32cube/stm32wbxx/drivers/src/stm32wbxx_ll_utils.c
@@ -132,7 +132,6 @@
   * @{
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency, LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK4_Frequency);
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 
@@ -497,19 +496,6 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEBypass, LL_UTILS_PLLInitTyp
   return status;
 }
 
-
-/**
-  * @}
-  */
-
-
-/**
-  * @}
-  */
-
-/** @addtogroup UTILS_LL_Private_Functions
-  * @{
-  */
 /**
   * @brief  Update number of Flash wait states in line with new frequency and current
             voltage range.
@@ -518,7 +504,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEBypass, LL_UTILS_PLLInitTyp
   *          - SUCCESS: Latency has been modified
   *          - ERROR: Latency cannot be modified
   */
-static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK4_Frequency)
+ErrorStatus LL_SetFlashLatency(uint32_t HCLK4_Frequency)
 {
   ErrorStatus status = SUCCESS;
   uint32_t latency   = LL_FLASH_LATENCY_0;  /* default value 0WS */
@@ -588,6 +574,19 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t HCLK4_Frequency)
   return status;
 }
 
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/** @addtogroup UTILS_LL_Private_Functions
+  * @{
+  */
 /**
   * @brief  Function to check that PLL can be modified
   * @param  PLL_InputFrequency  PLL input frequency (in Hz)
@@ -679,7 +678,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (hclks_frequency_current < hclks_frequency_target)
   {
     /* Set FLASH latency to highest latency */
-    status = UTILS_SetFlashLatency(hclks_frequency_target);
+    status = LL_SetFlashLatency(hclks_frequency_target);
   }
 
   /* Update system clock configuration */
@@ -712,7 +711,7 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   if (hclks_frequency_current > hclks_frequency_target)
   {
     /* Set FLASH latency to lowest latency */
-    status = UTILS_SetFlashLatency(hclks_frequency_target);
+    status = LL_SetFlashLatency(hclks_frequency_target);
   }
 
   /* Update SystemCoreClock variable */


### PR DESCRIPTION
The LL_SetFlashLatency public API is now defined for families
beyond G4, L4 and L5. In most case the private function has been
made public, in one case (H7) it's built on top of existing ones.

Signed-off-by: Giancarlo Stasi <giancarlo.stasi.co@gmail.com>