### PR TITLE
hal_stm32: add stm32h7xx_hal_rcc_ex.c

### DIFF
--- a/stm32cube/stm32h7xx/CMakeLists.txt
+++ b/stm32cube/stm32h7xx/CMakeLists.txt
@@ -6,6 +6,7 @@
 zephyr_library_sources(soc/system_stm32h7xx.c)
 zephyr_library_sources(drivers/src/stm32h7xx_hal.c)
 zephyr_library_sources(drivers/src/stm32h7xx_hal_rcc.c)
+zephyr_library_sources(drivers/src/stm32h7xx_hal_rcc_ex.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_ADC drivers/src/stm32h7xx_hal_adc.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_ADC_EX drivers/src/stm32h7xx_hal_adc_ex.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_CEC drivers/src/stm32h7xx_hal_cec.c)


### PR DESCRIPTION
Added missed stm32h7xx_hal_rcc_ex.c in CMakeLists.txt, which
may lead to undefined references
(e.g. HAL_RCCEx_GetD1SysClockFreq(...) )