### PR TITLE
stm32cube: update stm32f7 to version V1.16.0

### DIFF
--- a/stm32cube/stm32f7xx/README
+++ b/stm32cube/stm32f7xx/README
@@ -6,7 +6,7 @@ Origin:
    http://www.st.com/en/embedded-software/stm32cubef7.html
 
 Status:
-   version 1.15.0
+   version v1.16.0
 
 Purpose:
    ST Microelectronics official MCU package for STM32F7 series.
@@ -20,10 +20,10 @@ Dependencies:
     None.
 
 URL:
-   http://www.st.com/en/embedded-software/stm32cubef7.html
+   https://github.com/STMicroelectronics/STM32CubeF7
 
-commit:
-   version 1.15.0
+Commit:
+   79acbf8ec060d3ec751f2eaba6ee050269995357
 
 Maintained-by:
    External
@@ -35,7 +35,6 @@ License Link:
    https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
-   See release_note.html from STM32Cube
 
    *Fix LL_EXTI_LINE_18 and LL_EXTI_LINE_20 declarations
      LL_EXTI_LINE_18 and LL_EXTI_LINE_20 are declared in stm32f7xx_hal_pcd.h
@@ -44,3 +43,5 @@ Patch List:
     Impacted files:
      drivers/include/stm32f7xx_ll_exti.h
     ST Bug tracker ID: 55274
+
+   See release_note.html from STM32Cube


### PR DESCRIPTION
   Update Cube version for STM32F7xx series
   on https://github.com/STMicroelectronics
   from version v1.15.0
   to version v1.16.0

Signed-off-by: Francois Ramu <francois.ramu@st.com>