### PR TITLE
stm32cube: update stm32wb to version V1.7.0

### DIFF
--- a/stm32cube/stm32wbxx/README
+++ b/stm32cube/stm32wbxx/README
@@ -6,7 +6,7 @@ Origin:
    http://www.st.com/en/embedded-software/stm32cubewb.html
 
 Status:
-   version v1.5.0
+   version v1.7.0
 
 Purpose:
    ST Microelectronics official MCU package for STM32WB series.
@@ -23,7 +23,7 @@ URL:
    https://github.com/STMicroelectronics/STM32CubeWB
 
 Commit:
-   2b2c57a80d71ffeec182cc520e5a72af7b94778d
+   6f39fbe2a5edac79006e4c4dc527c1573713dcfc
 
 Maintained-by:
    External

--- a/stm32cube/stm32wbxx/release_note.html
+++ b/stm32cube/stm32wbxx/release_note.html
@@ -72,9 +72,866 @@
 <div class="col-sm-12 col-lg-8">
 <h1 id="update-history">Update History</h1>
 <div class="collapse">
-<input type="checkbox" id="collapse-section7" checked aria-hidden="true"> <label for="collapse-section7" aria-hidden="true">V1.5.0 / 14-February-2020</label>
+<input type="checkbox" id="collapse-section9" checked aria-hidden="true"> <label for="collapse-section9" aria-hidden="true">V1.7.0 / 11-May-2020</label>
 <div>
 <h2 id="main-changes">Main Changes</h2>
+<h3 id="correct-install-address-for-stm32wb5x_thread_ftd_fw.bin">Correct install address for stm32wb5x_Thread_FTD_fw.bin</h3>
+<h2 id="contents">Contents</h2>
+<h3 id="projects">Projects</h3>
+<p>The STM32CubeWB Firmware package comes with a rich set of examples running on STMicroelectronics boards, organized by board and provided with preconfigured projects for the main supported toolchains.</p>
+<p>The exhaustive list of projects and their short description is provided in this table (<a href="Projects/STM32CubeProjectsList.html">STM32CubeProjectsList.html</a>).</p>
+<ul>
+<li><strong>P-NUCLEO-WB55.Nucleo</strong> (<a href="Projects/P-NUCLEO-WB55.Nucleo/Release_Notes.html">release notes</a>)</li>
+<li><strong>P-NUCLEO-WB55.USBDongle</strong> (<a href="Projects/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a>)</li>
+<li><strong>NUCLEO-WB35CE</strong> (<a href="Projects/NUCLEO-WB35CE/Release_Notes.html">release notes</a>) (<a href="Projects/NUCLEO-WB35CE/Applications/BLE/BLE_p2pClient/readme.txt">default application</a>)</li>
+</ul>
+<h3 id="components">Components</h3>
+<table>
+<caption>STM32WB5x Firmware Upgrade Services Binary</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th style="text-align: left;">Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_FUS_fw_1_0_2.bin</td>
+<td style="text-align: left;">V1.0.2</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_FUS_fw.bin</td>
+<td style="text-align: left;">V1.1.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<caption>STM32WB5x Coprocessor Wireless Binaries</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th style="text-align: left;">Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_BLE_HCILayer_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_BLE_Stack_full_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_BLE_Stack_light_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_BLE_Thread_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_BLE_Zigbee_FFD_static_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_Mac_802_15_4_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_rfmonitor_phy802_15_4_fw.bin</td>
+<td style="text-align: left;">v1.1.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_Thread_FTD_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_Thread_MTD_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_Zigbee_FFD_Full_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_Zigbee_RFD_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<caption>STM32WB3x Coprocessor Wireless Binaries</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th style="text-align: left;">Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">stm32wb3x_BLE_HCILayer_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb3x_BLE_Stack_full_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb3x_BLE_Stack_light_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb3x_Mac_802_15_4_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb3x_Thread_FTD_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb3x_Thread_MTD_fw.bin</td>
+<td style="text-align: left;">v1.6.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<caption>Drivers</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th>Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">Cortex-M CMSIS</td>
+<td>V5.4.0</td>
+<td><a href="Drivers/CMSIS/LICENSE.txt">Apache License 2.0</a></td>
+<td><a href="Drivers/CMSIS/README.md">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">STM32WB CMSIS</td>
+<td>V1.4.0</td>
+<td><a href="Drivers/CMSIS/LICENSE.txt">Apache License 2.0</a></td>
+<td><a href="Drivers/CMSIS/Device/ST/STM32WBxx/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">STM32WBxx_HAL_Driver</td>
+<td>V1.5.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/STM32WBxx_HAL_Driver/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">P-NUCLEO-WB55.USBDongle</td>
+<td>V1.0.1</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">P-NUCLEO-WB55.Nucleo</td>
+<td>V1.0.1</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/P-NUCLEO-WB55.Nucleo/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">NUCLEO-WB35CE</td>
+<td>V1.0.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/NUCLEO-WB35CE/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">BSP Adafruit Shield</td>
+<td>V3.0.3</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/Adafruit_Shield/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">BSP Common</td>
+<td>V5.0.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/Components/Common/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">BSP st7735</td>
+<td>V1.1.2</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/Components/st7735/Release_Notes.html">release notes</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<caption>Middleware</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th style="text-align: left;">Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">STM32 USB Device Library</td>
+<td style="text-align: left;">V2.5.3</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044</a></td>
+<td><a href="Middlewares/ST/STM32_USB_Device_Library/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">STM32 WPAN</td>
+<td style="text-align: left;"><strong>V1.6.1</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044</a></td>
+<td><a href="Middlewares/ST/STM32_WPAN/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">FatFS</td>
+<td style="text-align: left;">R0.12c</td>
+<td><a href="Middlewares/Third_Party/FatFs/doc/en/appnote.html#license">FatFs License</a></td>
+<td><a href="Middlewares/Third_Party/FatFs/doc/updates.txt">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"></td>
+<td style="text-align: left;">ST modified 20191011</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044</a></td>
+<td><a href="Middlewares/Third_Party/FatFs/src/st_readme.txt">release notes ST</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">FreeRTOS</td>
+<td style="text-align: left;">V10.2.1</td>
+<td><a href="Middlewares/Third_Party/FreeRTOS/License/license.txt">MIT</a></td>
+<td><a href="Middlewares/Third_Party/FreeRTOS/Source/readme.txt">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"></td>
+<td style="text-align: left;">ST modified 20191213</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044</a></td>
+<td><a href="Middlewares/Third_Party/FreeRTOS/Source/st_readme.txt">release notes ST</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">STM32_TouchSensing_Library</td>
+<td style="text-align: left;">V2.2.4</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044</a></td>
+<td><a href="Middlewares/ST/STM32_TouchSensing_Library/Release_Notes.html">release notes</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<caption>Utilities</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th style="text-align: left;">Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">CPU</td>
+<td style="text-align: left;">V1.1.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/CPU/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">Fonts</td>
+<td style="text-align: left;">V1.0.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/Fonts/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">Log</td>
+<td style="text-align: left;">V1.0.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/Log/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">conf</td>
+<td style="text-align: left;">V1.3.1</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/conf/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">lpm</td>
+<td style="text-align: left;">V1.1.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/lpm/tiny_lpm/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">sequencer</td>
+<td style="text-align: left;">V1.2.1</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/sequencer/Release_Notes.html">release notes</a></td>
+</tr>
+</tbody>
+</table>
+<h2 id="known-limitations">Known Limitations</h2>
+<ul>
+<li>With the ability to change the Coprocessor Wireless Binaries Over The Air (OTA), it is possible to switch from one binary to another. Only, the following case is not possible due to available memory size:
+<ul>
+<li>Moving from stm32wb5x_BLE_Stack_fw.bin to stm32wb5x_BLE_Thread_fw.bin</li>
+</ul></li>
+</ul>
+<h2 id="development-toolchains-and-compilers">Development Toolchains and Compilers</h2>
+<ul>
+<li>IAR Embedded Workbench for ARM (EWARM) toolchain V8.20.2 + ST-Link</li>
+<li>RealView Microcontroller Development Kit (MDK-ARM) toolchain V5.25 + ST-Link</li>
+<li>System Workbench for STM32 (SW4STM32) toolchain V2.7 + ST-Link</li>
+<li>STM32CubeIDE toolchain V1.2.0 + ST-Link</li>
+</ul>
+<h2 id="supported-devices-and-boards">Supported Devices and boards</h2>
+<ul>
+<li>STM32WB55xx, STM32WB50xx, STM32WB35xx and STM32WB30xx devices.</li>
+<li>P-NUCLEO-WB55 kit composed of P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle</li>
+<li>NUCLEO-WB35CE board.</li>
+</ul>
+<h2 id="dependencies">Dependencies</h2>
+<p>This software release is compatible with:</p>
+<ul>
+<li>STM32WB_Copro_Wireless_Binaries available under Projects/STM32WB_Copro_Wireless_Binaries</li>
+</ul>
+<p>Several applications (BLE (Bluetooth low energy), Thread or Mac 802-15-4) are available under:</p>
+<ul>
+<li>Projects/P-NUCLEO-WB55.Nucleo/Applications</li>
+<li>Projects/P-NUCLEO-WB55.USBDongle/Applications</li>
+</ul>
+<p>All of them are provided in source code and some of them are also available in binary format directly for ready to use usage:</p>
+<ul>
+<li>Projects/P-NUCLEO-WB55.Nucleo/Applications/xxx/Binary/<projectName>.hex</li>
+<li>Projects/P-NUCLEO-WB55.USBDongle/Applications/xxx/Binary/<projectName>.hex</li>
+<li>Projects/NUCLEO-WB35CE/Applications/xxx/Binary/<projectName>.hex</li>
+</ul>
+<p>Each of them require a different coprocessor binary in order to behave correctly. This is documented inside each readme.txt of those applications.</p>
+<p>You can refer to the <a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note for STM32WB5x</a> or <a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note for STM32WB3x</a> of the binaries for a detailed explanation on how to use and how to flash them.</p>
+</div>
+</div>
+<div class="collapse">
+<input type="checkbox" id="collapse-section8"  aria-hidden="true"> <label for="collapse-section8" aria-hidden="true">V1.6.0 / 3-April-2020</label>
+<div>
+<h2 id="main-changes-1">Main Changes</h2>
+<h3 id="add-the-support-of-several-additional-zigbee-clusters">Add the support of several additional Zigbee clusters</h3>
+<ul>
+<li><strong>Zigbee</strong>
+<ul>
+<li>You can refer to <a href="Middlewares/ST/STM32_WPAN/zigbee/STM32WB_ZigbeeGettingStarted.pdf">STM32WB_ZigbeeGettingStarted.pdf</a> for a quick overview of Zigbee on STM32WB.</li>
+<li><strong>The package now supports the following cluster list (47 clusters)</strong>
+<ul>
+<li>Alarms</li>
+<li>Ballast Configuration</li>
+<li>Basic</li>
+<li>Color control</li>
+<li>Commissioning</li>
+<li>Dehumidification Control</li>
+<li>Demand Response and Load Control</li>
+<li>Device Temperature Configuration</li>
+<li>Diagnostics</li>
+<li>Door Lock</li>
+<li>Electrical Measurement</li>
+<li>Fan Control</li>
+<li>Green Power Proxy</li>
+<li>Groups</li>
+<li>IAS Ancillary Control Equipment (ACE)</li>
+<li>IAS Warning Device (WD)</li>
+<li>IAS Zone</li>
+<li>Identify6</li>
+<li>Illuminance Level Sensing</li>
+<li>Illuminance Measurement</li>
+<li>Key Establishment</li>
+<li>Level Control</li>
+<li>Messaging</li>
+<li>Meter Identification</li>
+<li>Metering</li>
+<li>Nearest Gateway Cluster</li>
+<li>OTA Upgrade</li>
+<li>Occupancy Sensing</li>
+<li>On/Off</li>
+<li>On/Off Switch Configuration</li>
+<li>Poll Control</li>
+<li>Power Configuration</li>
+<li>Power Profile Cluster</li>
+<li>Pressure Measurement</li>
+<li>Price</li>
+<li>Pump Configuration and Control</li>
+<li>RSSI Location</li>
+<li>Relative Humidity Measurement</li>
+<li>Scenes</li>
+<li>Smart Energy Tunneling (Complex Metering)</li>
+<li>Temperature Measurement</li>
+<li>Thermostat</li>
+<li>Thermostat User Interface Configuration</li>
+<li>Time</li>
+<li>Touchlink</li>
+<li>Voice Over ZigBee</li>
+<li>Window Covering</li>
+</ul></li>
+<li><strong>3 wireless stacks are available</strong>
+<ul>
+<li>stm32wb5x_Zigbee_FFD_Full_fw.bin (Full Function Device)</li>
+<li>stm32wb5x_Zigbee_RFD_fw.bin (new, Reduced Function Device to be used for End Device Zigbee role)</li>
+<li>stm32wb5x_BLE_Zigbee_FFD_static_fw.bin (Static Concurrent Mode BLE (Full BLE Stack 5.0) and Zigbee (FFD))</li>
+</ul></li>
+<li><strong>To demonstrate those clusters, several new applications are available</strong>
+<ul>
+<li>Zigbee_Commissioning_Client_Coord (Commissioning cluster)</li>
+<li>Zigbee_Commissioning_Server_Router (Commissioning cluster)</li>
+<li>Zigbee_Diagnostic_Client_Router (Diagnostics cluster)</li>
+<li>Zigbee_Diagnostic_Server_Coord (Diagnostics cluster)</li>
+<li>Zigbee_DoorLock_Client_Router (Door Lock cluster)</li>
+<li>Zigbee_DoorLock_Server_Coord (Door Lock cluster)</li>
+<li>Zigbee_IAS_WD_Client_Router (IAS Warning Device cluster)</li>
+<li>Zigbee_IAS_WD_Server_Coord (IAS Warning Device cluster)</li>
+<li>Zigbee_PollControl_Client_Coord (Poll Control cluster)</li>
+<li>Zigbee_PollControl_Server_SED (Poll Control cluster)</li>
+<li>(<a href="Projects/STM32CubeProjectsList.html">Complete list</a>)</li>
+</ul></li>
+</ul></li>
+<li><p><strong>BLE</strong></p>
+<ul>
+<li>BLE stack update to fix vulnerability referenced as CVE-2019-19192</li>
+</ul></li>
+<li><p><strong>BLE-Mesh</strong></p>
+<ul>
+<li><strong>Split the BLE_MeshLightingDemo project in two</strong>
+<ul>
+<li>BLE_MeshLightingLPN (Low Power Node)</li>
+<li>BLE_MeshLightingPRFNode (Proxy Relay Friend Node)</li>
+</ul></li>
+<li><strong>BLE-Mesh library version 1.12.007</strong>
+<ul>
+<li>Updated for Delta level set binding to Light lightness</li>
+<li>Multi Key updates.</li>
+<li>Correction of FSM issues in the LC Model: no way to consume a packet internally.</li>
+<li>Correction of Sensor_LC_Light_Publish sending wrong property (and LC Model handling wrong property).</li>
+<li>Updates on Generic Models for Certification tests: Generic OnOff, Level, Power OnOff, Transition Time<br />
+</li>
+<li>Update Multi elements support</li>
+<li>Changes for DYNAMIC_PROVISIONER in Provisioner project</li>
+</ul></li>
+</ul></li>
+</ul>
+<h2 id="contents-1">Contents</h2>
+<h3 id="projects-1">Projects</h3>
+<p>The STM32CubeWB Firmware package comes with a rich set of examples running on STMicroelectronics boards, organized by board and provided with preconfigured projects for the main supported toolchains.</p>
+<p>The exhaustive list of projects and their short description is provided in this table (<a href="Projects/STM32CubeProjectsList.html">STM32CubeProjectsList.html</a>).</p>
+<ul>
+<li><strong>P-NUCLEO-WB55.Nucleo</strong> (<a href="Projects/P-NUCLEO-WB55.Nucleo/Release_Notes.html">release notes</a>)</li>
+<li><strong>P-NUCLEO-WB55.USBDongle</strong> (<a href="Projects/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a>)</li>
+<li><strong>NUCLEO-WB35CE</strong> (<a href="Projects/NUCLEO-WB35CE/Release_Notes.html">release notes</a>) (<a href="Projects/NUCLEO-WB35CE/Applications/BLE/BLE_p2pClient/readme.txt">default application</a>)</li>
+</ul>
+<h3 id="components-1">Components</h3>
+<table>
+<caption>STM32WB5x Firmware Upgrade Services Binary</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th style="text-align: left;">Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_FUS_fw_1_0_2.bin</td>
+<td style="text-align: left;">V1.0.2</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_FUS_fw.bin</td>
+<td style="text-align: left;"><strong>V1.1.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<caption>STM32WB5x Coprocessor Wireless Binaries</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th style="text-align: left;">Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_BLE_HCILayer_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_BLE_Stack_full_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_BLE_Stack_light_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_BLE_Thread_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_BLE_Zigbee_FFD_static_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_Mac_802_15_4_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_rfmonitor_phy802_15_4_fw.bin</td>
+<td style="text-align: left;">v1.1.0</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_Thread_FTD_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_Thread_MTD_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb5x_Zigbee_FFD_Full_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb5x_Zigbee_RFD_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<caption>STM32WB3x Coprocessor Wireless Binaries</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th style="text-align: left;">Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">stm32wb3x_BLE_HCILayer_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb3x_BLE_Stack_full_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb3x_BLE_Stack_light_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb3x_Mac_802_15_4_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">stm32wb3x_Thread_FTD_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">stm32wb3x_Thread_MTD_fw.bin</td>
+<td style="text-align: left;"><strong>v1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044 (binary release)</a></td>
+<td><a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<caption>Drivers</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th>Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">Cortex-M CMSIS</td>
+<td>V5.4.0</td>
+<td><a href="Drivers/CMSIS/LICENSE.txt">Apache License 2.0</a></td>
+<td><a href="Drivers/CMSIS/README.md">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">STM32WB CMSIS</td>
+<td>V1.4.0</td>
+<td><a href="Drivers/CMSIS/LICENSE.txt">Apache License 2.0</a></td>
+<td><a href="Drivers/CMSIS/Device/ST/STM32WBxx/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">STM32WBxx_HAL_Driver</td>
+<td>V1.5.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/STM32WBxx_HAL_Driver/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">P-NUCLEO-WB55.USBDongle</td>
+<td>V1.0.1</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">P-NUCLEO-WB55.Nucleo</td>
+<td>V1.0.1</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/P-NUCLEO-WB55.Nucleo/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">NUCLEO-WB35CE</td>
+<td>V1.0.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/NUCLEO-WB35CE/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">BSP Adafruit Shield</td>
+<td>V3.0.3</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/Adafruit_Shield/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">BSP Common</td>
+<td>V5.0.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/Components/Common/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">BSP st7735</td>
+<td>V1.1.2</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Drivers/BSP/Components/st7735/Release_Notes.html">release notes</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<caption>Middleware</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th style="text-align: left;">Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">STM32 USB Device Library</td>
+<td style="text-align: left;">V2.5.3</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044</a></td>
+<td><a href="Middlewares/ST/STM32_USB_Device_Library/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">STM32 WPAN</td>
+<td style="text-align: left;"><strong>V1.6.0</strong></td>
+<td><a href="http://www.st.com/SLA0044">SLA0044</a></td>
+<td><a href="Middlewares/ST/STM32_WPAN/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">FatFS</td>
+<td style="text-align: left;">R0.12c</td>
+<td><a href="Middlewares/Third_Party/FatFs/doc/en/appnote.html#license">FatFs License</a></td>
+<td><a href="Middlewares/Third_Party/FatFs/doc/updates.txt">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"></td>
+<td style="text-align: left;">ST modified 20191011</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044</a></td>
+<td><a href="Middlewares/Third_Party/FatFs/src/st_readme.txt">release notes ST</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">FreeRTOS</td>
+<td style="text-align: left;">V10.2.1</td>
+<td><a href="Middlewares/Third_Party/FreeRTOS/License/license.txt">MIT</a></td>
+<td><a href="Middlewares/Third_Party/FreeRTOS/Source/readme.txt">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"></td>
+<td style="text-align: left;">ST modified 20191213</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044</a></td>
+<td><a href="Middlewares/Third_Party/FreeRTOS/Source/st_readme.txt">release notes ST</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">STM32_TouchSensing_Library</td>
+<td style="text-align: left;">V2.2.4</td>
+<td><a href="http://www.st.com/SLA0044">SLA0044</a></td>
+<td><a href="Middlewares/ST/STM32_TouchSensing_Library/Release_Notes.html">release notes</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<caption>Utilities</caption>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Name</th>
+<th style="text-align: left;">Version</th>
+<th>License</th>
+<th>Release note</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">CPU</td>
+<td style="text-align: left;">V1.1.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/CPU/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">Fonts</td>
+<td style="text-align: left;">V1.0.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/Fonts/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">Log</td>
+<td style="text-align: left;">V1.0.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/Log/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">conf</td>
+<td style="text-align: left;">V1.3.1</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/conf/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">lpm</td>
+<td style="text-align: left;">V1.1.0</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/lpm/tiny_lpm/Release_Notes.html">release notes</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">sequencer</td>
+<td style="text-align: left;">V1.2.1</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a></td>
+<td><a href="Utilities/sequencer/Release_Notes.html">release notes</a></td>
+</tr>
+</tbody>
+</table>
+<h2 id="known-limitations-1">Known Limitations</h2>
+<ul>
+<li>With the ability to change the Coprocessor Wireless Binaries Over The Air (OTA), it is possible to switch from one binary to another. Only, the following case is not possible due to available memory size:
+<ul>
+<li>Moving from stm32wb5x_BLE_Stack_fw.bin to stm32wb5x_BLE_Thread_fw.bin</li>
+</ul></li>
+</ul>
+<h2 id="development-toolchains-and-compilers-1">Development Toolchains and Compilers</h2>
+<ul>
+<li>IAR Embedded Workbench for ARM (EWARM) toolchain V8.20.2 + ST-Link</li>
+<li>RealView Microcontroller Development Kit (MDK-ARM) toolchain V5.25 + ST-Link</li>
+<li>System Workbench for STM32 (SW4STM32) toolchain V2.7 + ST-Link</li>
+<li>STM32CubeIDE toolchain V1.2.0 + ST-Link</li>
+</ul>
+<h2 id="supported-devices-and-boards-1">Supported Devices and boards</h2>
+<ul>
+<li>STM32WB55xx, STM32WB50xx, STM32WB35xx and STM32WB30xx devices.</li>
+<li>P-NUCLEO-WB55 kit composed of P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle</li>
+<li>NUCLEO-WB35CE board.</li>
+</ul>
+<h2 id="dependencies-1">Dependencies</h2>
+<p>This software release is compatible with:</p>
+<ul>
+<li>STM32WB_Copro_Wireless_Binaries available under Projects/STM32WB_Copro_Wireless_Binaries</li>
+</ul>
+<p>Several applications (BLE (Bluetooth low energy), Thread or Mac 802-15-4) are available under:</p>
+<ul>
+<li>Projects/P-NUCLEO-WB55.Nucleo/Applications</li>
+<li>Projects/P-NUCLEO-WB55.USBDongle/Applications</li>
+</ul>
+<p>All of them are provided in source code and some of them are also available in binary format directly for ready to use usage:</p>
+<ul>
+<li>Projects/P-NUCLEO-WB55.Nucleo/Applications/xxx/Binary/<projectName>.hex</li>
+<li>Projects/P-NUCLEO-WB55.USBDongle/Applications/xxx/Binary/<projectName>.hex</li>
+<li>Projects/NUCLEO-WB35CE/Applications/xxx/Binary/<projectName>.hex</li>
+</ul>
+<p>Each of them require a different coprocessor binary in order to behave correctly. This is documented inside each readme.txt of those applications.</p>
+<p>You can refer to the <a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html">release note for STM32WB5x</a> or <a href="Projects/STM32WB_Copro_Wireless_Binaries/STM32WB3x/Release_Notes.html">release note for STM32WB3x</a> of the binaries for a detailed explanation on how to use and how to flash them.</p>
+</div>
+</div>
+<div class="collapse">
+<input type="checkbox" id="collapse-section7"  aria-hidden="true"> <label for="collapse-section7" aria-hidden="true">V1.5.0 / 14-February-2020</label>
+<div>
+<h2 id="main-changes-2">Main Changes</h2>
 <h3 id="introduction-of-stm32wb5mxx-stm32wb35xx-stm32wb30xx-product-and-blezigbee-static-concurrent-mode">Introduction of STM32WB5Mxx, STM32WB35xx, STM32WB30xx product and BLE/Zigbee static concurrent mode</h3>
 <ul>
 <li><strong>STM32WB35xx</strong>:
@@ -187,8 +1044,8 @@
 <li>Introduce the support od STM32WB5Mxx inside the cmsis device, the HAL and the LL library.</li>
 </ul></li>
 </ul>
-<h2 id="contents">Contents</h2>
-<h3 id="projects">Projects</h3>
+<h2 id="contents-2">Contents</h2>
+<h3 id="projects-2">Projects</h3>
 <p>The STM32CubeWB Firmware package comes with a rich set of examples running on STMicroelectronics boards, organized by board and provided with preconfigured projects for the main supported toolchains.</p>
 <p>The exhaustive list of projects and their short description is provided in this table (<a href="Projects/STM32CubeProjectsList.html">STM32CubeProjectsList.html</a>).</p>
 <ul>
@@ -196,7 +1053,7 @@
 <li><strong>P-NUCLEO-WB55.USBDongle</strong> (<a href="Projects/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a>)</li>
 <li><strong>NUCLEO-WB35CE</strong> (<a href="Projects/NUCLEO-WB35CE/Release_Notes.html">release notes</a>) (<a href="Projects/NUCLEO-WB35CE/Applications/BLE/BLE_p2pClient/readme.txt">default application</a>)</li>
 </ul>
-<h3 id="components">Components</h3>
+<h3 id="components-2">Components</h3>
 <table>
 <caption>STM32WB5x Firmware Upgrade Services Binary</caption>
 <thead>
@@ -509,7 +1366,7 @@
 </tr>
 </tbody>
 </table>
-<h2 id="known-limitations">Known Limitations</h2>
+<h2 id="known-limitations-2">Known Limitations</h2>
 <ul>
 <li>With the ability to change the Coprocessor Wireless Binaries Over The Air (OTA), it is possible to switch from one binary to another. Only, the following case is not possible due to available memory size:
 <ul>
@@ -517,20 +1374,20 @@
 </ul></li>
 <li>The example RCC/RCC_ClockConfig encounter a hard fault after few keypressed. This will be corrected inside the next release.</li>
 </ul>
-<h2 id="development-toolchains-and-compilers">Development Toolchains and Compilers</h2>
+<h2 id="development-toolchains-and-compilers-2">Development Toolchains and Compilers</h2>
 <ul>
 <li>IAR Embedded Workbench for ARM (EWARM) toolchain V8.20.2 + ST-Link</li>
 <li>RealView Microcontroller Development Kit (MDK-ARM) toolchain V5.25 + ST-Link</li>
 <li>System Workbench for STM32 (SW4STM32) toolchain V2.7 + ST-Link</li>
 <li>STM32CubeIDE toolchain V1.2.0 + ST-Link</li>
 </ul>
-<h2 id="supported-devices-and-boards">Supported Devices and boards</h2>
+<h2 id="supported-devices-and-boards-2">Supported Devices and boards</h2>
 <ul>
 <li>STM32WB55xx, STM32WB50xx, STM32WB35xx and STM32WB30xx devices.</li>
 <li>P-NUCLEO-WB55 kit composed of P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle</li>
 <li>NUCLEO-WB35CE board.</li>
 </ul>
-<h2 id="dependencies">Dependencies</h2>
+<h2 id="dependencies-2">Dependencies</h2>
 <p>This software release is compatible with:</p>
 <ul>
 <li>STM32WB_Copro_Wireless_Binaries available under Projects/STM32WB_Copro_Wireless_Binaries</li>
@@ -553,7 +1410,7 @@
 <div class="collapse">
 <input type="checkbox" id="collapse-section6"  aria-hidden="true"> <label for="collapse-section6" aria-hidden="true">V1.4.0 / 06-December-2019</label>
 <div>
-<h2 id="main-changes-1">Main Changes</h2>
+<h2 id="main-changes-3">Main Changes</h2>
 <h3 id="maintenance-release">Maintenance Release</h3>
 <ul>
 <li><strong>BLE</strong>:
@@ -578,15 +1435,15 @@
 </ul></li>
 <li>Maintenance release for HAL and LL drivers.</li>
 </ul>
-<h2 id="contents-1">Contents</h2>
-<h3 id="projects-1">Projects</h3>
+<h2 id="contents-3">Contents</h2>
+<h3 id="projects-3">Projects</h3>
 <p>The STM32CubeWB Firmware package comes with a rich set of examples running on STMicroelectronics boards, organized by board and provided with preconfigured projects for the main supported toolchains.</p>
 <p>The exhaustive list of projects and their short description is provided in this table (<a href="Projects/STM32CubeProjectsList.html">STM32CubeProjectsList.html</a>).</p>
 <ul>
 <li><strong>P-NUCLEO-WB55.Nucleo</strong> (<a href="Projects/P-NUCLEO-WB55.Nucleo/Release_Notes.html">release notes</a>) (<a href="Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_p2pServer/readme.txt">default application</a>)</li>
 <li><strong>P-NUCLEO-WB55.USBDongle</strong> (<a href="Projects/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a>) (<a href="Projects/P-NUCLEO-WB55.USBDongle/Applications/BLE/BLE_p2pClient/readme.txt">default application</a>)</li>
 </ul>
-<h3 id="components-1">Components</h3>
+<h3 id="components-3">Components</h3>
 <table>
 <caption>Firmware Upgrade Services Binary</caption>
 <thead>
@@ -832,7 +1689,7 @@
 </tr>
 </tbody>
 </table>
-<h2 id="known-limitations-1">Known Limitations</h2>
+<h2 id="known-limitations-3">Known Limitations</h2>
 <ul>
 <li>With the ability to change the Coprocessor Wireless Binaries Over The Air (OTA), it is possible to switch from one binary to another. Only, the following case is not possible due to available memory size:
 <ul>
@@ -840,18 +1697,18 @@
 </ul></li>
 <li>BLE_MeshLightingDemo application is not functionnal under Linux platform.</li>
 </ul>
-<h2 id="development-toolchains-and-compilers-1">Development Toolchains and Compilers</h2>
+<h2 id="development-toolchains-and-compilers-3">Development Toolchains and Compilers</h2>
 <ul>
 <li>IAR Embedded Workbench for ARM (EWARM) toolchain V8.20.2 + ST-Link</li>
 <li>RealView Microcontroller Development Kit (MDK-ARM) toolchain V5.25 + ST-Link</li>
 <li>System Workbench for STM32 (SW4STM32) toolchain V2.7 + ST-Link</li>
 </ul>
-<h2 id="supported-devices-and-boards-1">Supported Devices and boards</h2>
+<h2 id="supported-devices-and-boards-3">Supported Devices and boards</h2>
 <ul>
 <li>STM32WB55xx and STM32WB50xx devices</li>
 <li>P-NUCLEO-WB55 kit composed of P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle</li>
 </ul>
-<h2 id="dependencies-1">Dependencies</h2>
+<h2 id="dependencies-3">Dependencies</h2>
 <p>This software release is compatible with:</p>
 <ul>
 <li>STM32WB_Copro_Wireless_Binaries available under Projects/STM32WB_Copro_Wireless_Binaries</li>
@@ -873,7 +1730,7 @@
 <div class="collapse">
 <input type="checkbox" id="collapse-section5" aria-hidden="true"> <label for="collapse-section5" aria-hidden="true">V1.3.0 / 11-September-2019</label>
 <div>
-<h2 id="main-changes-2">Main Changes</h2>
+<h2 id="main-changes-4">Main Changes</h2>
 <h3 id="introduction-of-zigbee-support">Introduction of ZIGBEE support</h3>
 <p>STM32WB ecosystem keeps growing, now with the introduction of ZigBee protocol support as <strong>certified compliant platform</strong>, running on <strong>certified 802.15.4 2015 LLD MAC and PHY</strong>.</p>
 <p>The wireless stack is based on <strong>ZigBee pro 2017, R22 release version</strong> in order to propose a ZigBee 3.0 solution. First ON/OFF cluster is coming in this STM32CubeWB Firmware Package delivery release.</p>
@@ -902,15 +1759,15 @@
 <li>Integration of BLE Mesh library v1.10.004</li>
 <li>Maintenance release for CMSIS, HAL and LL drivers.</li>
 </ul>
-<h2 id="contents-2">Contents</h2>
-<h3 id="projects-2">Projects</h3>
+<h2 id="contents-4">Contents</h2>
+<h3 id="projects-4">Projects</h3>
 <p>The STM32CubeWB Firmware package comes with a rich set of examples running on STMicroelectronics boards, organized by board and provided with preconfigured projects for the main supported toolchains.</p>
 <p>The exhaustive list of projects and their short description is provided in this table (<a href="Projects/STM32CubeProjectsList.html">STM32CubeProjectsList.html</a>).</p>
 <ul>
 <li><strong>P-NUCLEO-WB55.Nucleo</strong> (<a href="Projects/P-NUCLEO-WB55.Nucleo/Release_Notes.html">release notes</a>) (<a href="Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_p2pServer/readme.txt">default application</a>)</li>
 <li><strong>P-NUCLEO-WB55.USBDongle</strong> (<a href="Projects/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a>) (<a href="Projects/P-NUCLEO-WB55.USBDongle/Applications/BLE/BLE_p2pClient/readme.txt">default application</a>)</li>
 </ul>
-<h3 id="components-2">Components</h3>
+<h3 id="components-4">Components</h3>
 <table>
 <caption>Firmware Upgrade Services Binary</caption>
 <thead>
@@ -1150,7 +2007,7 @@
 </tr>
 </tbody>
 </table>
-<h2 id="known-limitations-2">Known Limitations</h2>
+<h2 id="known-limitations-4">Known Limitations</h2>
 <ul>
 <li>With the ability to change the Coprocessor Wireless Binaries Over The Air (OTA), it is possible to switch from one binary to another. Only, the following case is not possible due to available memory size:
 <ul>
@@ -1159,18 +2016,18 @@
 <li>Mac 802-15-4 applications are provided with EWARM IDE. MDK-ARM and SW4STM32 IDE are planned for a future release.</li>
 <li>BLE_MeshLightingDemo application is not functionnal under Linux platform.</li>
 </ul>
-<h2 id="development-toolchains-and-compilers-2">Development Toolchains and Compilers</h2>
+<h2 id="development-toolchains-and-compilers-4">Development Toolchains and Compilers</h2>
 <ul>
 <li>IAR Embedded Workbench for ARM (EWARM) toolchain V8.20.2 + ST-Link</li>
 <li>RealView Microcontroller Development Kit (MDK-ARM) toolchain V5.25 + ST-Link</li>
 <li>System Workbench for STM32 (SW4STM32) toolchain V2.7 + ST-Link</li>
 </ul>
-<h2 id="supported-devices-and-boards-2">Supported Devices and boards</h2>
+<h2 id="supported-devices-and-boards-4">Supported Devices and boards</h2>
 <ul>
 <li>STM32WB55xx and STM32WB50xx devices</li>
 <li>P-NUCLEO-WB55 kit composed of P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle</li>
 </ul>
-<h2 id="dependencies-2">Dependencies</h2>
+<h2 id="dependencies-4">Dependencies</h2>
 <p>This software release is compatible with:</p>
 <ul>
 <li>STM32WB_Copro_Wireless_Binaries available under Projects/STM32WB_Copro_Wireless_Binaries</li>
@@ -1192,7 +2049,7 @@
 <div class="collapse">
 <input type="checkbox" id="collapse-section4" aria-hidden="true"> <label for="collapse-section4" aria-hidden="true">V1.2.0 / 3rd-July-2019</label>
 <div>
-<h2 id="main-changes-3">Main Changes</h2>
+<h2 id="main-changes-5">Main Changes</h2>
 <h3 id="stm32wb50xx-introduction-and-new-features-addition">STM32WB50xx introduction and new features addition</h3>
 <p>This release introduces the following feature:</p>
 <ul>
@@ -1219,15 +2076,15 @@
 <li>Mesh Library V1.10.000</li>
 </ul></li>
 </ul>
-<h2 id="contents-3">Contents</h2>
-<h3 id="projects-3">Projects</h3>
+<h2 id="contents-5">Contents</h2>
+<h3 id="projects-5">Projects</h3>
 <p>The STM32CubeWB Firmware package comes with a rich set of examples running on STMicroelectronics boards, organized by board and provided with preconfigured projects for the main supported toolchains.</p>
 <p>The exhaustive list of projects and their short description is provided in this table (<a href="Projects/STM32CubeProjectsList.html">STM32CubeProjectsList.html</a>).</p>
 <ul>
 <li><strong>P-NUCLEO-WB55.Nucleo</strong> (<a href="Projects/P-NUCLEO-WB55.Nucleo/Release_Notes.html">release notes</a>) (<a href="Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_p2pServer/readme.txt">default application</a>)</li>
 <li><strong>P-NUCLEO-WB55.USBDongle</strong> (<a href="Projects/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a>) (<a href="Projects/P-NUCLEO-WB55.USBDongle/Applications/BLE/BLE_p2pClient/readme.txt">default application</a>)</li>
 </ul>
-<h3 id="components-3">Components</h3>
+<h3 id="components-5">Components</h3>
 <table>
 <caption>Firmware Upgrade Services Binary</caption>
 <thead>
@@ -1467,7 +2324,7 @@
 </tr>
 </tbody>
 </table>
-<h2 id="known-limitations-3">Known Limitations</h2>
+<h2 id="known-limitations-5">Known Limitations</h2>
 <ul>
 <li>With the ability to change the Coprocessor Wireless Binaries Over The Air (OTA), it is possible to switch from one binary to another. Only, the following case is not possible due to available memory size:
 <ul>
@@ -1477,18 +2334,18 @@
 <li>BLE_MeshLightingDemo application is not functionnal under Linux platform.</li>
 <li>Zigbee supports only OnOff cluster.</li>
 </ul>
-<h2 id="development-toolchains-and-compilers-3">Development Toolchains and Compilers</h2>
+<h2 id="development-toolchains-and-compilers-5">Development Toolchains and Compilers</h2>
 <ul>
 <li>IAR Embedded Workbench for ARM (EWARM) toolchain V8.20.2 + ST-Link</li>
 <li>RealView Microcontroller Development Kit (MDK-ARM) toolchain V5.25 + ST-Link</li>
 <li>System Workbench for STM32 (SW4STM32) toolchain V2.7 + ST-Link</li>
 </ul>
-<h2 id="supported-devices-and-boards-3">Supported Devices and boards</h2>
+<h2 id="supported-devices-and-boards-5">Supported Devices and boards</h2>
 <ul>
 <li>STM32WB55xx and STM32WB50xx devices</li>
 <li>P-NUCLEO-WB55 kit composed of P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle</li>
 </ul>
-<h2 id="dependencies-3">Dependencies</h2>
+<h2 id="dependencies-5">Dependencies</h2>
 <p>This software release is compatible with:</p>
 <ul>
 <li>STM32WB_Copro_Wireless_Binaries available under Projects/STM32WB_Copro_Wireless_Binaries</li>
@@ -1510,7 +2367,7 @@
 <div class="collapse">
 <input type="checkbox" id="collapse-section3" aria-hidden="true"> <label for="collapse-section3" aria-hidden="true">V1.1.1 / 17-May-2019</label>
 <div>
-<h2 id="main-changes-4">Main Changes</h2>
+<h2 id="main-changes-6">Main Changes</h2>
 <h3 id="patch-release-for-fus-v1.0.2wireless-coprocessor-binary-bug-fix-and-ble-mesh-library-improvements">Patch release for FUS V1.0.2,Wireless Coprocessor Binary bug fix and BLE Mesh Library improvements</h3>
 <p>This release introduces the following feature:</p>
 <ul>
@@ -1536,8 +2393,8 @@
 </ul></li>
 </ul></li>
 </ul>
-<h2 id="contents-4">Contents</h2>
-<h3 id="projects-4">Projects</h3>
+<h2 id="contents-6">Contents</h2>
+<h3 id="projects-6">Projects</h3>
 <p>The STM32CubeWB Firmware package comes with a rich set of examples running on STMicroelectronics boards, organized by board and provided with preconfigured projects for the main supported toolchains.</p>
 <p>The exhaustive list of projects and their short description is provided in this table (<a href="Projects/STM32CubeProjectsList.html">STM32CubeProjectsList.html</a>).</p>
 <ul>
@@ -1545,7 +2402,7 @@
 <li><strong>P-NUCLEO-WB55.USBDongle</strong> (<a href="Projects/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a>) (<a href="Projects/P-NUCLEO-WB55.USBDongle/Applications/BLE/BLE_p2pClient/readme.txt">default application</a>)</li>
 </ul>
 <p><em>Please note that the path of the example projects have been change to P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle.</em></p>
-<h3 id="components-4">Components</h3>
+<h3 id="components-6">Components</h3>
 <table>
 <caption>Firmware Upgrade Services Binary</caption>
 <thead>
@@ -1767,7 +2624,7 @@
 </tr>
 </tbody>
 </table>
-<h2 id="known-limitations-4">Known Limitations</h2>
+<h2 id="known-limitations-6">Known Limitations</h2>
 <ul>
 <li>With the ability to change the Coprocessor Wireless Binaries Over The Air (OTA), it is possible to switch from one binary to another. Only, the following case is not possible due to available memory size:
 <ul>
@@ -1785,18 +2642,18 @@
 <li>SW4STM32 project is compiled without optimisation. (With optimised size compilation, the virtual com port required for the application is not functionnal)</li>
 </ul></li>
 </ul>
-<h2 id="development-toolchains-and-compilers-4">Development Toolchains and Compilers</h2>
+<h2 id="development-toolchains-and-compilers-6">Development Toolchains and Compilers</h2>
 <ul>
 <li>IAR Embedded Workbench for ARM (EWARM) toolchain V8.20.2 + ST-Link</li>
 <li>RealView Microcontroller Development Kit (MDK-ARM) toolchain V5.25 + ST-Link</li>
 <li>System Workbench for STM32 (SW4STM32) toolchain V2.7 + ST-Link</li>
 </ul>
-<h2 id="supported-devices-and-boards-4">Supported Devices and boards</h2>
+<h2 id="supported-devices-and-boards-6">Supported Devices and boards</h2>
 <ul>
 <li>STM32WB55xx devices</li>
 <li>P-NUCLEO-WB55 kit composed of P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle</li>
 </ul>
-<h2 id="dependencies-4">Dependencies</h2>
+<h2 id="dependencies-6">Dependencies</h2>
 <p>This software release is compatible with:</p>
 <ul>
 <li>STM32WB_Copro_Wireless_Binaries available under Projects/STM32WB_Copro_Wireless_Binaries</li>
@@ -1818,7 +2675,7 @@
 <div class="collapse">
 <input type="checkbox" id="collapse-section2" aria-hidden="true"> <label for="collapse-section2" aria-hidden="true">V1.1.0 / 05-April-2019</label>
 <div>
-<h2 id="main-changes-5">Main Changes</h2>
+<h2 id="main-changes-7">Main Changes</h2>
 <h3 id="new-features-introduction-and-maintenance-release">New features introduction and maintenance release</h3>
 <p>This release introduces the following feature:</p>
 <ul>
@@ -1880,8 +2737,8 @@
 <li>Projects\P-NUCLEO-WB55.USBDongle\Applications\BLE</li>
 <li>Projects\P-NUCLEO-WB55.USBDongle\Applications\Thread</li>
 </ul>
-<h2 id="contents-5">Contents</h2>
-<h3 id="projects-5">Projects</h3>
+<h2 id="contents-7">Contents</h2>
+<h3 id="projects-7">Projects</h3>
 <p>The STM32CubeWB Firmware package comes with a rich set of examples running on STMicroelectronics boards, organized by board and provided with preconfigured projects for the main supported toolchains.</p>
 <p>The exhaustive list of projects and their short description is provided in this table (<a href="Projects/STM32CubeProjectsList.html">STM32CubeProjectsList.html</a>).</p>
 <ul>
@@ -1889,7 +2746,7 @@
 <li><strong>P-NUCLEO-WB55.USBDongle</strong> (<a href="Projects/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a>) (<a href="Projects/P-NUCLEO-WB55.USBDongle/Applications/BLE/BLE_p2pClient/readme.txt">default application</a>)</li>
 </ul>
 <p><em>Please note that the path of the example projects have been change to P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle.</em></p>
-<h3 id="components-5">Components</h3>
+<h3 id="components-7">Components</h3>
 <table>
 <caption>Firmware Upgrade Services Binary</caption>
 <thead>
@@ -2111,7 +2968,7 @@
 </tr>
 </tbody>
 </table>
-<h2 id="known-limitations-5">Known Limitations</h2>
+<h2 id="known-limitations-7">Known Limitations</h2>
 <ul>
 <li>With the ability to change the Coprocessor Wireless Binaries Over The Air (OTA), it is possible to switch from one binary to another. Only, the following case is not possible due to available memory size:
 <ul>
@@ -2129,18 +2986,18 @@
 <li>SW4STM32 project is compiled without optimisation. (With optimised size compilation, the virtual com port required for the application is not functionnal)</li>
 </ul></li>
 </ul>
-<h2 id="development-toolchains-and-compilers-5">Development Toolchains and Compilers</h2>
+<h2 id="development-toolchains-and-compilers-7">Development Toolchains and Compilers</h2>
 <ul>
 <li>IAR Embedded Workbench for ARM (EWARM) toolchain V8.20.2 + ST-Link</li>
 <li>RealView Microcontroller Development Kit (MDK-ARM) toolchain V5.25 + ST-Link</li>
 <li>System Workbench for STM32 (SW4STM32) toolchain V2.7 + ST-Link</li>
 </ul>
-<h2 id="supported-devices-and-boards-5">Supported Devices and boards</h2>
+<h2 id="supported-devices-and-boards-7">Supported Devices and boards</h2>
 <ul>
 <li>STM32WB55xx devices</li>
 <li>P-NUCLEO-WB55 kit composed of P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle</li>
 </ul>
-<h2 id="dependencies-5">Dependencies</h2>
+<h2 id="dependencies-7">Dependencies</h2>
 <p>This software release is compatible with:</p>
 <ul>
 <li>STM32WB_Copro_Wireless_Binaries available under Projects/STM32WB_Copro_Wireless_Binaries</li>
@@ -2162,7 +3019,7 @@
 <div class="collapse">
 <input type="checkbox" id="collapse-section1" aria-hidden="true"> <label for="collapse-section1" aria-hidden="true">V1.0.0 / 06-February-2019</label>
 <div>
-<h2 id="main-changes-6">Main Changes</h2>
+<h2 id="main-changes-8">Main Changes</h2>
 <h3 id="first-release">First release</h3>
 <p>First release of STM32CubeWB (STM32Cube for STM32WB Series) supporting STM32WB55xx devices.</p>
 <p>In the STM32CubeWB MCU Package, most of the examples and applications projects are generated with the STM32CubeMX tool to initialize the system, peripherals and middleware stacks.</p>
@@ -2178,15 +3035,15 @@
 <li>Projects\P-NUCLEO-WB55.USBDongle\Applications\BLE</li>
 <li>Projects\P-NUCLEO-WB55.USBDongle\Applications\Thread</li>
 </ul>
-<h2 id="contents-6">Contents</h2>
-<h3 id="projects-6">Projects</h3>
+<h2 id="contents-8">Contents</h2>
+<h3 id="projects-8">Projects</h3>
 <p>The STM32CubeWB Firmware package comes with a rich set of examples running on STMicroelectronics boards, organized by board and provided with preconfigured projects for the main supported toolchains.</p>
 <p>The exhaustive list of projects and their short description is provided in this table (<a href="Projects/STM32CubeProjectsList.html">STM32CubeProjectsList.html</a>).</p>
 <ul>
 <li><strong>P-NUCLEO-WB55.Nucleo</strong> (<a href="Projects/P-NUCLEO-WB55.Nucleo/Release_Notes.html">release notes</a>) (<a href="Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_p2pServer/readme.txt">default application</a>)</li>
 <li><strong>P-NUCLEO-WB55.USBDongle</strong> (<a href="Projects/P-NUCLEO-WB55.USBDongle/Release_Notes.html">release notes</a>) (<a href="Projects/P-NUCLEO-WB55.USBDongle/Applications/BLE/BLE_p2pClient/readme.txt">default application</a>)</li>
 </ul>
-<h3 id="components-6">Components</h3>
+<h3 id="components-8">Components</h3>
 <table>
 <caption>Coprocessor Wireless Binaries</caption>
 <thead>
@@ -2377,7 +3234,7 @@
 </tr>
 </tbody>
 </table>
-<h2 id="known-limitations-6">Known Limitations</h2>
+<h2 id="known-limitations-8">Known Limitations</h2>
 <ul>
 <li>BLE\BLE_p2pClient is provided with EWARM and MDK-ARM IDE. A connection issue with BLE_p2pServer is encounter with SW4STM32.</li>
 <li>BLE\BLE_p2pRouter is provided with EWARM and MDK-ARM IDE. A connection issue with BLE_p2pServer is encounter with SW4STM32.</li>
@@ -2407,18 +3264,18 @@
 </ul></li>
 </ul></li>
 </ul>
-<h2 id="development-toolchains-and-compilers-6">Development Toolchains and Compilers</h2>
+<h2 id="development-toolchains-and-compilers-8">Development Toolchains and Compilers</h2>
 <ul>
 <li>IAR Embedded Workbench for ARM (EWARM) toolchain V8.20.2 + ST-Link</li>
 <li>RealView Microcontroller Development Kit (MDK-ARM) toolchain V5.25 + ST-Link</li>
 <li>System Workbench for STM32 (SW4STM32) toolchain V2.7 + ST-Link</li>
 </ul>
-<h2 id="supported-devices-and-boards-6">Supported Devices and boards</h2>
+<h2 id="supported-devices-and-boards-8">Supported Devices and boards</h2>
 <ul>
 <li>STM32WB55xx devices</li>
 <li>P-NUCLEO-WB55 kit composed of P-NUCLEO-WB55.Nucleo and P-NUCLEO-WB55.USBDongle</li>
 </ul>
-<h2 id="dependencies-6">Dependencies</h2>
+<h2 id="dependencies-8">Dependencies</h2>
 <p>This software release is compatible with:</p>
 <ul>
 <li>STM32WB_Copro_Wireless_Binaries available under Projects/STM32WB_Copro_Wireless_Binaries</li>


### PR DESCRIPTION
   Update Cube version for STM32WBxx series
   on https://github.com/STMicroelectronics
   from version v1.5.0
   to version v1.7.0

Signed-off-by: Francois Ramu <francois.ramu@st.com>