### PR TITLE
scripts: genpinctrl: handle pin names with extra description

### DIFF
--- a/dts/st/f0/stm32f030cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030cctx-pinctrl.dtsi
@@ -72,6 +72,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -106,6 +112,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f030rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030rctx-pinctrl.dtsi
@@ -96,6 +96,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -130,6 +136,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
@@ -84,6 +84,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -112,6 +118,12 @@
 
 			i2c1_sda_pb11: i2c1_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
@@ -84,6 +84,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -112,6 +118,12 @@
 
 			i2c1_sda_pb11: i2c1_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f042f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f4px-pinctrl.dtsi
@@ -68,10 +68,22 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f042f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f6px-pinctrl.dtsi
@@ -68,10 +68,22 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -88,6 +94,12 @@
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -94,6 +100,12 @@
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -94,6 +100,12 @@
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -94,6 +100,12 @@
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
@@ -84,6 +84,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -112,6 +118,12 @@
 
 			i2c1_sda_pb11: i2c1_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
@@ -74,6 +74,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -84,6 +90,12 @@
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -94,6 +100,12 @@
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
@@ -72,6 +72,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -88,6 +94,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f070f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070f6px-pinctrl.dtsi
@@ -62,10 +62,22 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
@@ -82,6 +82,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -116,6 +122,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
@@ -82,6 +82,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -116,6 +122,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f091rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rchx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f091vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091vchx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f098cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098cctx-pinctrl.dtsi
@@ -82,6 +82,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -116,6 +122,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f098ccux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098ccux-pinctrl.dtsi
@@ -82,6 +82,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -116,6 +122,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f098rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rchx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f098rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rctx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f098vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vchx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f098vctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vctx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf1: i2c1_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa11: i2c2_scl_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf0: i2c1_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -208,6 +212,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -290,6 +298,14 @@
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -208,6 +212,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -309,6 +317,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -228,6 +232,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -326,6 +334,14 @@
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -232,6 +236,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -330,6 +338,14 @@
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -228,6 +232,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -345,6 +353,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -232,6 +236,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -349,6 +357,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -232,6 +236,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -381,6 +389,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -260,6 +264,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -393,6 +401,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -260,6 +264,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -425,6 +433,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -260,6 +264,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -425,6 +433,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -158,6 +162,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -208,6 +216,14 @@
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -158,6 +162,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -227,6 +235,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -158,6 +162,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -227,6 +235,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -182,6 +186,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -248,6 +256,14 @@
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -182,6 +186,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -267,6 +275,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -226,6 +230,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -311,6 +319,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -234,6 +238,10 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -335,6 +343,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -178,6 +182,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -263,6 +271,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -148,6 +152,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -190,6 +198,14 @@
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -148,6 +152,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -198,6 +206,14 @@
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -182,6 +186,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -283,6 +291,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -226,6 +230,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -327,6 +335,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -234,6 +238,10 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -359,6 +367,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -226,6 +230,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -327,6 +335,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -242,6 +246,10 @@
 				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -375,6 +383,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -158,6 +162,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -208,6 +216,14 @@
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -158,6 +162,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -227,6 +235,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -182,6 +186,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -248,6 +256,14 @@
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -182,6 +186,10 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -267,6 +275,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -46,6 +50,10 @@
 
 			adc1_in9_pb1: adc1_in9_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -234,6 +242,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -284,6 +296,14 @@
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -46,6 +50,10 @@
 
 			adc1_in9_pb1: adc1_in9_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -234,6 +242,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -303,6 +315,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -46,6 +50,10 @@
 
 			adc1_in9_pb1: adc1_in9_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -234,6 +242,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -284,6 +296,14 @@
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -46,6 +50,10 @@
 
 			adc1_in9_pb1: adc1_in9_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -234,6 +242,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -303,6 +315,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -66,6 +70,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -274,6 +282,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -340,6 +352,14 @@
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -282,6 +290,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -348,6 +360,14 @@
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -66,6 +70,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -274,6 +282,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -359,6 +371,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -282,6 +290,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -367,6 +379,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -372,6 +384,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -457,6 +473,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -68,6 +72,10 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -122,6 +130,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -360,6 +372,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -445,6 +461,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -380,6 +392,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -481,6 +497,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -46,6 +50,10 @@
 
 			adc1_in9_pb1: adc1_in9_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -212,6 +220,10 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -254,6 +266,14 @@
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -46,6 +50,10 @@
 
 			adc1_in9_pb1: adc1_in9_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -212,6 +220,10 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -262,6 +274,14 @@
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS */

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -310,6 +318,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -411,6 +423,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -310,6 +318,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -411,6 +423,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -400,6 +412,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -501,6 +517,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -400,6 +412,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -501,6 +517,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -408,6 +420,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -533,6 +549,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -310,6 +318,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -411,6 +423,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -420,6 +432,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -521,6 +537,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -420,6 +432,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -521,6 +537,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -436,6 +448,10 @@
 				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -569,6 +585,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -436,6 +448,10 @@
 				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -569,6 +585,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -426,6 +434,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -511,6 +523,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -462,6 +470,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -563,6 +575,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -462,6 +470,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -563,6 +575,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -426,6 +434,10 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -511,6 +523,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -462,6 +470,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -563,6 +575,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
 			};
@@ -70,6 +74,10 @@
 
 			adc1_in15_pc5: adc1_in15_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
 			adc2_in1_pa1: adc2_in1_pa1 {
@@ -462,6 +470,10 @@
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
@@ -563,6 +575,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;

--- a/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -476,6 +488,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -580,6 +596,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -644,6 +664,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -736,6 +762,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -476,6 +488,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -580,6 +596,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -644,6 +664,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -736,6 +762,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f205rgex-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205rgex-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -476,6 +488,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -580,6 +596,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -644,6 +664,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -736,6 +762,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -513,6 +525,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -633,6 +649,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -705,6 +725,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -839,6 +865,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -565,6 +577,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -693,6 +709,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -765,6 +785,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -927,6 +953,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -626,6 +638,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -762,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -878,6 +898,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1040,6 +1066,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -626,6 +638,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -762,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -878,6 +898,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1040,6 +1066,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -513,6 +525,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -633,6 +649,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -705,6 +725,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -839,6 +865,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -565,6 +577,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -693,6 +709,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -765,6 +785,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -927,6 +953,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -476,6 +488,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -580,6 +596,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -644,6 +664,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -736,6 +762,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -513,6 +525,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -633,6 +649,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -705,6 +725,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -839,6 +865,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -565,6 +577,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -693,6 +709,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -765,6 +785,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -927,6 +953,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -626,6 +638,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -762,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -878,6 +898,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1040,6 +1066,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -626,6 +638,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -762,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -878,6 +898,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1040,6 +1066,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -513,6 +525,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -633,6 +649,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -705,6 +725,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -839,6 +865,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -565,6 +577,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -693,6 +709,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -765,6 +785,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -927,6 +953,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
@@ -88,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -120,6 +126,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -130,6 +142,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -154,6 +170,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -205,6 +225,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -219,6 +244,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -279,6 +309,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
@@ -88,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -120,6 +126,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -130,6 +142,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -154,6 +170,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -205,6 +225,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -219,6 +244,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -279,6 +309,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
@@ -74,6 +74,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -100,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -107,6 +119,10 @@
 			};
 
 			/* I2S_CK */
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -123,6 +139,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
@@ -158,6 +178,11 @@
 
 			/* SPI_NSS */
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -169,6 +194,11 @@
 			};
 
 			/* SPI_SCK */
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -211,6 +241,10 @@
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
@@ -70,6 +70,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -96,6 +102,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -103,6 +115,10 @@
 			};
 
 			/* I2S_CK */
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -119,6 +135,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
@@ -154,6 +174,11 @@
 
 			/* SPI_NSS */
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -165,6 +190,11 @@
 			};
 
 			/* SPI_SCK */
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -203,6 +233,10 @@
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
@@ -104,6 +104,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -136,6 +142,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -152,6 +164,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -184,6 +200,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -245,6 +265,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -259,6 +284,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -340,6 +370,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
@@ -88,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -120,6 +126,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -130,6 +142,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -154,6 +170,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -205,6 +225,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -219,6 +244,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -279,6 +309,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
@@ -80,6 +80,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa14: i2c1_sda_pa14 {
@@ -102,6 +108,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -285,6 +297,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
@@ -88,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -120,6 +126,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -130,6 +142,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -154,6 +170,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -205,6 +225,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -219,6 +244,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -279,6 +309,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
@@ -70,6 +70,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -96,6 +102,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -103,6 +115,10 @@
 			};
 
 			/* I2S_CK */
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -119,6 +135,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
@@ -154,6 +174,11 @@
 
 			/* SPI_NSS */
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -165,6 +190,11 @@
 			};
 
 			/* SPI_SCK */
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -203,6 +233,10 @@
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
@@ -104,6 +104,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -136,6 +142,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -152,6 +164,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -184,6 +200,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -245,6 +265,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -259,6 +284,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -340,6 +370,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
@@ -124,6 +124,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa14: i2c1_sda_pa14 {
@@ -146,6 +152,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -352,6 +364,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
@@ -128,6 +128,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -160,6 +166,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -176,6 +188,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -208,6 +224,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -299,6 +319,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -323,6 +348,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -404,6 +434,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
@@ -132,6 +132,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -160,6 +166,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -409,6 +421,10 @@
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -136,6 +136,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -174,6 +180,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -190,6 +202,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -222,6 +238,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -338,6 +358,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -377,6 +402,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -506,6 +536,10 @@
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -136,6 +136,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -174,6 +180,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -190,6 +202,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -222,6 +238,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -338,6 +358,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -377,6 +402,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -506,6 +536,10 @@
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
@@ -128,6 +128,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -156,6 +162,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -389,6 +401,10 @@
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -140,6 +140,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -178,6 +184,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -194,6 +206,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -226,6 +242,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -342,6 +362,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -381,6 +406,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -510,6 +540,10 @@
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
@@ -228,6 +228,10 @@
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
@@ -108,6 +108,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa14: i2c1_sda_pa14 {
@@ -130,6 +136,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -313,6 +325,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
@@ -244,6 +244,10 @@
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
@@ -180,6 +180,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
@@ -172,6 +172,10 @@
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
@@ -284,6 +284,10 @@
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
@@ -152,6 +152,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa14: i2c1_sda_pa14 {
@@ -174,6 +180,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -380,6 +392,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
@@ -156,6 +156,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -188,6 +194,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -204,6 +216,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -236,6 +252,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -327,6 +347,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -351,6 +376,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -432,6 +462,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
@@ -248,6 +248,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -276,6 +282,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -525,6 +537,10 @@
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -252,6 +252,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -290,6 +296,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -306,6 +318,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -338,6 +354,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -454,6 +474,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -493,6 +518,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -650,6 +680,10 @@
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -252,6 +252,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -290,6 +296,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -306,6 +318,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -338,6 +354,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -454,6 +474,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -493,6 +518,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -650,6 +680,10 @@
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
@@ -220,6 +220,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -248,6 +254,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -481,6 +493,10 @@
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f303veyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303veyx-pinctrl.dtsi
@@ -228,6 +228,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -266,6 +272,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -282,6 +294,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -314,6 +330,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -420,6 +440,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -459,6 +484,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -600,6 +630,10 @@
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -256,6 +256,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -294,6 +300,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -310,6 +322,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -342,6 +358,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -458,6 +478,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -497,6 +522,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -702,6 +732,10 @@
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
@@ -88,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -120,6 +126,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -130,6 +142,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -154,6 +170,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -205,6 +225,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -219,6 +244,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -279,6 +309,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
@@ -88,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -120,6 +126,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -130,6 +142,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -154,6 +170,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -205,6 +225,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -219,6 +244,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -279,6 +309,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
@@ -70,6 +70,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_scl_pa8: i2c3_scl_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF3)>;
 				bias-pull-up;
@@ -90,6 +96,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -97,6 +109,10 @@
 			};
 
 			/* I2S_CK */
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -113,6 +129,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
@@ -148,6 +168,11 @@
 
 			/* SPI_NSS */
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -159,6 +184,11 @@
 			};
 
 			/* SPI_SCK */
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -197,6 +227,10 @@
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
@@ -224,6 +224,10 @@
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
@@ -228,6 +228,10 @@
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
@@ -244,6 +244,10 @@
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
@@ -180,6 +180,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
@@ -172,6 +172,10 @@
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
@@ -284,6 +284,10 @@
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};

--- a/dts/st/f3/stm32f358cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358cctx-pinctrl.dtsi
@@ -104,6 +104,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa14: i2c1_sda_pa14 {
@@ -126,6 +132,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -309,6 +321,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f358rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358rctx-pinctrl.dtsi
@@ -148,6 +148,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa14: i2c1_sda_pa14 {
@@ -170,6 +176,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -376,6 +388,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f358vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358vctx-pinctrl.dtsi
@@ -244,6 +244,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -272,6 +278,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -521,6 +533,10 @@
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
@@ -88,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -116,6 +122,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
@@ -116,6 +116,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -144,6 +150,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
@@ -116,6 +116,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -144,6 +150,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
@@ -116,6 +116,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -144,6 +150,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f3/stm32f378cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378cctx-pinctrl.dtsi
@@ -88,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -116,6 +122,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f3/stm32f378rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rctx-pinctrl.dtsi
@@ -116,6 +116,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -144,6 +150,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
@@ -116,6 +116,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -144,6 +150,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f3/stm32f378vchx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vchx-pinctrl.dtsi
@@ -116,6 +116,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -144,6 +150,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f3/stm32f378vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vctx-pinctrl.dtsi
@@ -116,6 +116,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -144,6 +150,12 @@
 
 			i2c2_sda_pa10: i2c2_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f3/stm32f398vetx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f398vetx-pinctrl.dtsi
@@ -248,6 +248,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf1: i2c2_scl_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pf6: i2c2_scl_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF4)>;
 				bias-pull-up;
@@ -286,6 +292,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -302,6 +314,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -334,6 +350,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -450,6 +470,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -489,6 +514,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -646,6 +676,10 @@
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {

--- a/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -295,6 +299,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -363,6 +371,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -387,6 +399,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -295,6 +299,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -363,6 +371,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -387,6 +399,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -295,6 +299,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -363,6 +371,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -387,6 +399,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -295,6 +299,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -363,6 +371,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -387,6 +399,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -295,6 +299,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -363,6 +371,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -387,6 +399,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -362,6 +366,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -446,6 +454,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -470,6 +482,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -362,6 +366,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -446,6 +454,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -470,6 +482,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -454,6 +458,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -558,6 +566,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -590,6 +602,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -448,6 +452,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -548,6 +556,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -580,6 +592,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -454,6 +458,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -558,6 +566,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -590,6 +602,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -448,6 +452,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -548,6 +556,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -580,6 +592,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -60,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -106,6 +114,10 @@
 
 			adc2_in13_pc3: adc2_in13_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -521,6 +533,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -637,6 +653,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -705,6 +725,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -833,6 +859,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -494,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -598,6 +614,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -662,6 +682,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -754,6 +780,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -531,6 +543,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -651,6 +667,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -723,6 +743,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -857,6 +883,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -583,6 +595,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -711,6 +727,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -783,6 +803,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -945,6 +971,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -648,6 +660,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -784,6 +800,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -900,6 +920,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1062,6 +1088,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -648,6 +660,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -784,6 +800,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -900,6 +920,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1062,6 +1088,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -531,6 +543,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -651,6 +667,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -723,6 +743,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -857,6 +883,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -583,6 +595,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -711,6 +727,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -783,6 +803,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -945,6 +971,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -290,6 +294,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -318,6 +326,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -315,6 +319,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -343,6 +351,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -372,6 +376,10 @@
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -420,6 +428,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -372,6 +376,10 @@
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -420,6 +428,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in2_pa2: adc1_in2_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
 			};
@@ -125,6 +129,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
@@ -143,6 +151,14 @@
 
 			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/* UART_CTS / USART_CTS / LPUART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */

--- a/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -413,6 +417,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -481,6 +489,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -505,6 +517,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -413,6 +417,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -481,6 +489,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -505,6 +517,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -489,6 +493,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -573,6 +581,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -597,6 +609,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -669,6 +673,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -773,6 +781,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -805,6 +817,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -663,6 +667,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -763,6 +771,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -795,6 +807,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -60,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -106,6 +114,10 @@
 
 			adc2_in13_pc3: adc2_in13_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -521,6 +533,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -637,6 +653,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -705,6 +725,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -833,6 +859,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -494,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -598,6 +614,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -662,6 +682,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -754,6 +780,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -531,6 +543,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -651,6 +667,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -723,6 +743,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -857,6 +883,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -583,6 +595,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -711,6 +727,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -783,6 +803,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -945,6 +971,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -648,6 +660,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -784,6 +800,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -900,6 +920,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1062,6 +1088,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -648,6 +660,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -784,6 +800,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -900,6 +920,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1062,6 +1088,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -531,6 +543,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -651,6 +667,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -723,6 +743,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -857,6 +883,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -583,6 +595,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -711,6 +727,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -783,6 +803,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -945,6 +971,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -702,6 +714,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -830,6 +846,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -946,6 +966,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1106,6 +1132,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -589,6 +601,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -709,6 +725,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -781,6 +801,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -923,6 +949,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -814,6 +830,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -886,6 +906,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1060,6 +1086,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -702,6 +714,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -830,6 +846,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -946,6 +966,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1106,6 +1132,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -589,6 +601,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -709,6 +725,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -781,6 +801,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -923,6 +949,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -589,6 +601,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -709,6 +725,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -781,6 +801,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -923,6 +949,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -814,6 +830,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -886,6 +906,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1060,6 +1086,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -814,6 +830,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -886,6 +906,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1060,6 +1086,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -814,6 +830,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -886,6 +906,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1060,6 +1086,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -814,6 +830,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -886,6 +906,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1060,6 +1086,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -702,6 +714,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -830,6 +846,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -946,6 +966,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1106,6 +1132,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -589,6 +601,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -709,6 +725,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -781,6 +801,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -923,6 +949,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -814,6 +830,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -886,6 +906,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1060,6 +1086,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -702,6 +714,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -830,6 +846,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -946,6 +966,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1106,6 +1132,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -766,6 +778,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -902,6 +918,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1018,6 +1038,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1192,6 +1218,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -589,6 +601,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -709,6 +725,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -781,6 +801,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -923,6 +949,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -814,6 +830,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -886,6 +906,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1060,6 +1086,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -814,6 +830,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -886,6 +906,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1060,6 +1086,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -64,6 +68,10 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +122,10 @@
 
 			adc2_in14_pc4: adc2_in14_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -618,6 +630,10 @@
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -738,6 +754,10 @@
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -802,6 +822,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -940,6 +966,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -593,6 +605,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -705,6 +721,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -769,6 +789,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -885,6 +911,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -711,6 +723,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -839,6 +855,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -911,6 +931,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1073,6 +1099,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -789,6 +801,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -929,6 +945,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1001,6 +1021,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1195,6 +1221,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -789,6 +801,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -929,6 +945,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1001,6 +1021,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1195,6 +1221,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -789,6 +801,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -929,6 +945,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1001,6 +1021,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1195,6 +1221,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -98,6 +106,10 @@
 
 			adc2_in11_pc1: adc2_in11_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -655,6 +667,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -779,6 +795,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -895,6 +915,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1065,6 +1091,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -98,6 +106,10 @@
 
 			adc2_in11_pc1: adc2_in11_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -655,6 +667,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -779,6 +795,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -895,6 +915,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1065,6 +1091,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -784,6 +796,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -920,6 +936,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1036,6 +1056,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1210,6 +1236,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -769,6 +781,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -901,6 +917,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -989,6 +1009,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1163,6 +1189,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -769,6 +781,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -901,6 +917,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -989,6 +1009,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1163,6 +1189,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -769,6 +781,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -901,6 +917,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -989,6 +1009,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1163,6 +1189,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -784,6 +796,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -920,6 +936,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1036,6 +1056,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1210,6 +1236,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -784,6 +796,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -920,6 +936,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1036,6 +1056,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1210,6 +1236,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -64,6 +68,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +122,10 @@
 
 			adc2_in13_pc3: adc2_in13_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -576,6 +588,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -688,6 +704,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -752,6 +772,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -878,6 +904,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -64,6 +68,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +122,10 @@
 
 			adc2_in13_pc3: adc2_in13_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -576,6 +588,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -688,6 +704,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -752,6 +772,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -878,6 +904,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -635,6 +647,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -751,6 +767,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -823,6 +843,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -987,6 +1013,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -635,6 +647,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -751,6 +767,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -823,6 +843,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -987,6 +1013,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -98,6 +106,10 @@
 
 			adc2_in11_pc1: adc2_in11_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -655,6 +667,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -779,6 +795,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -895,6 +915,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1065,6 +1091,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -98,6 +106,10 @@
 
 			adc2_in11_pc1: adc2_in11_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -655,6 +667,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -779,6 +795,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -895,6 +915,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1065,6 +1091,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -784,6 +796,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -920,6 +936,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1036,6 +1056,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1210,6 +1236,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -769,6 +781,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -901,6 +917,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -989,6 +1009,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1163,6 +1189,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -769,6 +781,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -901,6 +917,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -989,6 +1009,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1163,6 +1189,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -784,6 +796,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -920,6 +936,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1036,6 +1056,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1210,6 +1236,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -64,6 +68,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +122,10 @@
 
 			adc2_in13_pc3: adc2_in13_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -576,6 +588,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -688,6 +704,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -752,6 +772,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -878,6 +904,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -635,6 +647,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -751,6 +767,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -823,6 +843,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -987,6 +1013,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -793,6 +805,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -929,6 +945,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1045,6 +1065,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1287,6 +1313,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -793,6 +805,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -929,6 +945,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1045,6 +1065,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1287,6 +1313,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -68,6 +72,10 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -122,6 +130,10 @@
 
 			adc2_in14_pc4: adc2_in14_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -528,6 +540,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -632,6 +648,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -696,6 +716,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -812,6 +838,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -631,6 +643,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -751,6 +767,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -823,6 +843,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1013,6 +1039,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -708,6 +720,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -836,6 +852,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -908,6 +928,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1142,6 +1168,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -771,6 +783,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -899,6 +915,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1007,6 +1027,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1243,6 +1269,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -771,6 +783,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -899,6 +915,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1007,6 +1027,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1243,6 +1269,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -609,6 +621,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -721,6 +737,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -785,6 +805,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -960,6 +986,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -806,6 +822,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -870,6 +890,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1098,6 +1124,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -806,6 +822,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -870,6 +890,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1098,6 +1124,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -771,6 +783,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -899,6 +915,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1007,6 +1027,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1243,6 +1269,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -68,6 +72,10 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -122,6 +130,10 @@
 
 			adc2_in14_pc4: adc2_in14_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -528,6 +540,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -632,6 +648,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -696,6 +716,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -812,6 +838,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -631,6 +643,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -751,6 +767,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -823,6 +843,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1013,6 +1039,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -806,6 +822,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -870,6 +890,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1098,6 +1124,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -793,6 +805,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -929,6 +945,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1045,6 +1065,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1287,6 +1313,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -793,6 +805,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -929,6 +945,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1045,6 +1065,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1287,6 +1313,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -68,6 +72,10 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -122,6 +130,10 @@
 
 			adc2_in14_pc4: adc2_in14_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -528,6 +540,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -632,6 +648,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -696,6 +716,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -812,6 +838,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -631,6 +643,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -751,6 +767,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -823,6 +843,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1013,6 +1039,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -708,6 +720,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -836,6 +852,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -908,6 +928,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1142,6 +1168,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -771,6 +783,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -899,6 +915,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1007,6 +1027,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1243,6 +1269,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -771,6 +783,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -899,6 +915,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1007,6 +1027,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1243,6 +1269,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -609,6 +621,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -721,6 +737,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -785,6 +805,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -960,6 +986,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -806,6 +822,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -870,6 +890,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1098,6 +1124,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -686,6 +698,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -806,6 +822,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -870,6 +890,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1098,6 +1124,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -661,6 +673,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -781,6 +797,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -853,6 +873,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1043,6 +1069,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -661,6 +673,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -781,6 +797,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -853,6 +873,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1043,6 +1069,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -898,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -970,6 +990,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1204,6 +1230,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -661,6 +673,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -781,6 +797,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -853,6 +873,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1043,6 +1069,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -661,6 +673,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -781,6 +797,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -853,6 +873,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1043,6 +1069,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -661,6 +673,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -781,6 +797,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -853,6 +873,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1043,6 +1069,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -898,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -970,6 +990,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1204,6 +1230,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -898,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -970,6 +990,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1204,6 +1230,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -898,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -970,6 +990,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1204,6 +1230,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -661,6 +673,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -781,6 +797,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -853,6 +873,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1043,6 +1069,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -898,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -970,6 +990,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1204,6 +1230,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -862,6 +874,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -998,6 +1014,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1114,6 +1134,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1348,6 +1374,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -661,6 +673,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -781,6 +797,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -853,6 +873,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1043,6 +1069,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -661,6 +673,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -781,6 +797,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -853,6 +873,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1043,6 +1069,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -898,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -970,6 +990,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1204,6 +1230,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -898,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -970,6 +990,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1204,6 +1230,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -890,6 +906,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -962,6 +982,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1201,6 +1227,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -890,6 +906,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -962,6 +982,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1201,6 +1227,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -902,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1030,6 +1046,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1102,6 +1122,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1385,6 +1411,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -890,6 +906,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -962,6 +982,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1201,6 +1227,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -890,6 +906,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -962,6 +982,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1201,6 +1227,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -890,6 +906,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -962,6 +982,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1201,6 +1227,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -890,6 +906,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -962,6 +982,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1201,6 +1227,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -902,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1030,6 +1046,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1102,6 +1122,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1385,6 +1411,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -902,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1030,6 +1046,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1102,6 +1122,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1385,6 +1411,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -98,6 +106,10 @@
 
 			adc2_in11_pc1: adc2_in11_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -870,6 +882,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -994,6 +1010,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1110,6 +1130,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1385,6 +1411,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -98,6 +106,10 @@
 
 			adc2_in11_pc1: adc2_in11_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -870,6 +882,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -994,6 +1010,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1110,6 +1130,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1385,6 +1411,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -967,6 +979,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1099,6 +1115,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1187,6 +1207,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1474,6 +1500,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -967,6 +979,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1099,6 +1115,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1187,6 +1207,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1474,6 +1500,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -890,6 +906,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -962,6 +982,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1201,6 +1227,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -770,6 +782,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -890,6 +906,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -962,6 +982,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1201,6 +1227,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -902,6 +914,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1030,6 +1046,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1102,6 +1122,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1385,6 +1411,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -98,6 +106,10 @@
 
 			adc2_in11_pc1: adc2_in11_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -870,6 +882,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -994,6 +1010,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1110,6 +1130,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1385,6 +1411,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -98,6 +106,10 @@
 
 			adc2_in11_pc1: adc2_in11_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -870,6 +882,10 @@
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -994,6 +1010,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1110,6 +1130,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1385,6 +1411,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -967,6 +979,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1099,6 +1115,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1187,6 +1207,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1474,6 +1500,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in0_pa0: adc1_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in1_pa1: adc1_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -72,6 +76,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in0_pa0: adc2_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa1: adc2_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -130,6 +138,10 @@
 
 			adc2_in15_pc5: adc2_in15_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc3_in0_pa0: adc3_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
 			adc3_in1_pa1: adc3_in1_pa1 {
@@ -999,6 +1011,10 @@
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -1135,6 +1151,10 @@
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -1251,6 +1271,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1542,6 +1568,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
 			};
 
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
 			adc1_in8_pb0: adc1_in8_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -84,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -92,6 +102,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +132,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -124,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -164,6 +192,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -189,6 +221,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -196,6 +233,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -236,6 +278,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -243,6 +290,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -359,8 +411,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -443,6 +507,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
@@ -477,6 +545,12 @@
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -497,6 +571,12 @@
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 				bias-pull-up;
@@ -510,6 +590,10 @@
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
@@ -534,6 +618,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -541,6 +630,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g030f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030f6px-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -66,6 +78,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -78,7 +96,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
@@ -88,6 +118,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +152,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -141,6 +181,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -148,6 +193,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -173,6 +223,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -180,6 +235,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -250,6 +310,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -330,6 +402,12 @@
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -343,6 +421,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
@@ -358,6 +442,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -372,6 +460,11 @@
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -379,6 +472,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
@@ -24,8 +24,20 @@
 				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -42,6 +54,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -54,7 +72,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
@@ -64,6 +94,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -78,6 +114,10 @@
 
 			i2s1_sd_pa2: i2s1_sd_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
+			};
+
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
 			};
 
 			i2s1_sd_pb5: i2s1_sd_pb5 {
@@ -96,6 +136,16 @@
 
 			/* SPI_MISO */
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -108,8 +158,18 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -163,6 +223,18 @@
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
+			};
+
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
@@ -207,13 +279,38 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			/* UART_CTS / USART_CTS / LPUART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
+
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;

--- a/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -72,6 +84,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -84,7 +102,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -100,6 +130,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -128,6 +164,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -153,6 +193,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -160,6 +205,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -190,6 +240,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -197,6 +252,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -278,8 +338,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -364,6 +436,12 @@
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -378,6 +456,12 @@
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 				bias-pull-up;
@@ -391,6 +475,10 @@
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
@@ -415,6 +503,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -422,6 +515,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
 			};
 
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
 			adc1_in8_pb0: adc1_in8_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -84,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -92,6 +102,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +132,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -124,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -164,6 +192,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -189,6 +221,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -196,6 +233,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -236,6 +278,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -243,6 +290,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -359,8 +411,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -487,6 +551,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
@@ -527,6 +595,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -552,6 +626,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -587,6 +667,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -615,6 +699,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -627,6 +716,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
 			};
 
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
 			adc1_in8_pb0: adc1_in8_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -84,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -92,6 +102,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +132,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -124,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -164,6 +192,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -189,6 +221,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -196,6 +233,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -236,6 +278,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -243,6 +290,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -359,8 +411,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -487,6 +551,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
@@ -527,6 +595,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -552,6 +626,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -587,6 +667,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -615,6 +699,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -627,6 +716,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -66,6 +78,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -78,7 +96,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
@@ -88,6 +118,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +152,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -141,6 +181,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -148,6 +193,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -173,6 +223,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -180,6 +235,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -250,6 +310,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -364,6 +436,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -377,6 +455,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -402,6 +486,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -421,6 +509,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -428,6 +521,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -62,6 +74,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -74,10 +92,28 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -106,6 +142,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -131,6 +171,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -138,6 +183,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -158,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -165,6 +220,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -230,6 +290,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -348,6 +420,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -361,6 +439,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -386,6 +470,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -405,6 +493,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -412,6 +505,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
@@ -24,8 +24,20 @@
 				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -42,6 +54,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -54,7 +72,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
@@ -64,6 +94,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -78,6 +114,10 @@
 
 			i2s1_sd_pa2: i2s1_sd_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
+			};
+
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
 			};
 
 			i2s1_sd_pb5: i2s1_sd_pb5 {
@@ -96,6 +136,16 @@
 
 			/* SPI_MISO */
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -108,8 +158,18 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -161,6 +221,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -223,7 +295,21 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			/* UART_CTS / USART_CTS / LPUART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -233,6 +319,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -241,6 +331,11 @@
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				bias-pull-up;
+			};
+
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -72,6 +84,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -84,7 +102,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -100,6 +130,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -128,6 +164,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -153,6 +193,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -160,6 +205,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -190,6 +240,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -197,6 +252,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -278,8 +338,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -402,6 +474,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -415,6 +493,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -438,6 +522,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -468,6 +556,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -475,6 +568,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -72,6 +84,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -84,7 +102,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -100,6 +130,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -128,6 +164,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -153,6 +193,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -160,6 +205,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -190,6 +240,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -197,6 +252,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -278,8 +338,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -402,6 +474,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -415,6 +493,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -438,6 +522,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -468,6 +556,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -475,6 +568,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -66,6 +78,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -78,7 +96,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
@@ -88,6 +118,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +152,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -141,6 +181,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -148,6 +193,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -173,6 +223,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -180,6 +235,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -250,6 +310,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -364,6 +436,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -377,6 +455,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -402,6 +486,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -421,6 +509,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -428,6 +521,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
 			};
 
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
 			adc1_in8_pb0: adc1_in8_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -84,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -92,6 +102,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +132,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -124,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -164,6 +192,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -189,6 +221,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -196,6 +233,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -236,6 +278,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -243,6 +290,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -359,8 +411,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -487,6 +551,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
@@ -527,6 +595,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -552,6 +626,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -587,6 +667,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -615,6 +699,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -627,6 +716,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
 			};
 
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
 			adc1_in8_pb0: adc1_in8_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -84,6 +88,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -92,6 +102,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +132,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -124,6 +146,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -164,6 +192,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -189,6 +221,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -196,6 +233,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -236,6 +278,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -243,6 +290,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -359,8 +411,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -487,6 +551,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
@@ -527,6 +595,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -552,6 +626,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -587,6 +667,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -615,6 +699,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -627,6 +716,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -66,6 +78,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -78,7 +96,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
@@ -88,6 +118,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +152,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -141,6 +181,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -148,6 +193,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -173,6 +223,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -180,6 +235,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -250,6 +310,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -364,6 +436,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -377,6 +455,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -402,6 +486,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -421,6 +509,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -428,6 +521,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -62,6 +74,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -74,10 +92,28 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -106,6 +142,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -131,6 +171,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -138,6 +183,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -158,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -165,6 +220,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -230,6 +290,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -348,6 +420,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -361,6 +439,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -386,6 +470,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -405,6 +493,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -412,6 +505,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
@@ -24,8 +24,20 @@
 				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -42,6 +54,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -54,7 +72,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
@@ -64,6 +94,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -78,6 +114,10 @@
 
 			i2s1_sd_pa2: i2s1_sd_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
+			};
+
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
 			};
 
 			i2s1_sd_pb5: i2s1_sd_pb5 {
@@ -96,6 +136,16 @@
 
 			/* SPI_MISO */
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -108,8 +158,18 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -161,6 +221,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -223,7 +295,21 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			/* UART_CTS / USART_CTS / LPUART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -233,6 +319,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -241,6 +331,11 @@
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				bias-pull-up;
+			};
+
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -72,6 +84,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -84,7 +102,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -100,6 +130,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -128,6 +164,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -153,6 +193,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -160,6 +205,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -190,6 +240,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -197,6 +252,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -278,8 +338,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -402,6 +474,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -415,6 +493,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -438,6 +522,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -468,6 +556,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -475,6 +568,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -72,6 +84,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -84,7 +102,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -100,6 +130,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -128,6 +164,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -153,6 +193,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -160,6 +205,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -190,6 +240,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -197,6 +252,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -278,8 +338,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -402,6 +474,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -415,6 +493,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -438,6 +522,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -468,6 +556,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -475,6 +568,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
@@ -44,8 +44,20 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc1_in15_pa11: adc1_in15_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			adc1_in16_pa12: adc1_in16_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			adc1_in17_pa13: adc1_in17_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			adc1_in18_pa14: adc1_in18_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
 			};
 
 			adc1_in8_pb0: adc1_in8_pb0 {
@@ -66,6 +78,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -78,7 +96,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
@@ -88,6 +118,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +152,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -141,6 +181,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -148,6 +193,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -173,6 +223,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -180,6 +235,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -250,6 +310,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -364,6 +436,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -377,6 +455,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -402,6 +486,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -421,6 +509,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -428,6 +521,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
@@ -76,6 +76,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -84,6 +90,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -108,6 +120,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -116,6 +134,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -156,6 +180,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -181,6 +209,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -188,6 +221,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -228,6 +266,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -235,6 +278,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -351,8 +399,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -435,6 +495,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
@@ -461,6 +525,10 @@
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
+			};
+
+			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
@@ -496,6 +564,12 @@
 			};
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
@@ -534,6 +608,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
@@ -583,6 +663,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -618,6 +702,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -625,6 +714,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
@@ -64,6 +64,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -76,7 +82,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -92,6 +110,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -120,6 +144,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -145,6 +173,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -152,6 +185,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -182,6 +220,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -189,6 +232,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -270,8 +318,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -368,6 +428,12 @@
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -393,6 +459,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
@@ -430,6 +502,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -461,6 +537,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -468,6 +549,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
@@ -84,6 +84,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -92,6 +98,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -116,6 +128,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -124,6 +142,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -168,6 +192,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -201,6 +229,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -213,6 +246,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -258,6 +296,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -270,6 +313,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -406,8 +454,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -522,6 +582,10 @@
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
@@ -558,6 +622,10 @@
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
+			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF2)>;
+			};
+
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
@@ -591,6 +659,12 @@
 			};
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
@@ -629,6 +703,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
@@ -679,6 +759,10 @@
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
@@ -743,6 +827,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -755,6 +844,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
@@ -86,6 +86,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -94,6 +100,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -118,6 +130,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -126,6 +144,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -166,6 +190,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -191,6 +219,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -198,6 +231,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -238,6 +276,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -245,6 +288,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -361,8 +409,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -489,6 +549,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
@@ -515,6 +579,10 @@
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
+			};
+
+			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
@@ -553,6 +621,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -600,6 +674,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -665,6 +745,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -709,6 +793,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -721,6 +810,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
@@ -86,6 +86,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -94,6 +100,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -118,6 +130,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -126,6 +144,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -166,6 +190,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -191,6 +219,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -198,6 +231,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -238,6 +276,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -245,6 +288,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -361,8 +409,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -489,6 +549,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
@@ -515,6 +579,10 @@
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
+			};
+
+			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
@@ -553,6 +621,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -600,6 +674,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -665,6 +745,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -709,6 +793,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -721,6 +810,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
@@ -64,6 +64,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -76,10 +82,28 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -102,6 +126,10 @@
 
 			i2s1_sd_pa7: i2s1_sd_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
+			};
+
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
 			};
 
 			i2s1_sd_pb5: i2s1_sd_pb5 {
@@ -129,8 +157,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -151,6 +189,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -158,6 +201,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -218,6 +266,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -328,6 +388,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 				bias-pull-up;
@@ -347,6 +413,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -384,6 +456,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -411,6 +487,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -418,6 +499,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
@@ -64,6 +64,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -76,10 +82,28 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -108,6 +132,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -133,6 +161,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -140,6 +173,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -160,6 +198,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -167,6 +210,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -232,6 +280,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -362,6 +422,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -387,6 +453,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -430,6 +502,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -457,6 +533,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -464,6 +545,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
@@ -60,6 +60,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -72,10 +78,28 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -100,6 +124,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			/* I2S_WS */
 
 			i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -117,8 +145,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -144,8 +182,18 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -216,6 +264,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -342,6 +402,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 				bias-pull-up;
@@ -368,6 +434,12 @@
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 				bias-pull-up;
@@ -384,6 +456,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
@@ -409,6 +485,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -416,6 +497,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
@@ -74,6 +74,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -86,7 +92,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -102,6 +120,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -130,6 +154,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -155,6 +183,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -162,6 +195,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -192,6 +230,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -199,6 +242,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -280,8 +328,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -416,6 +476,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -441,6 +507,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -488,6 +560,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -524,6 +600,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -531,6 +612,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
@@ -74,6 +74,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -86,7 +92,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -102,6 +120,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -130,6 +154,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -155,6 +183,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -162,6 +195,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -192,6 +230,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -199,6 +242,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -280,8 +328,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -416,6 +476,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -441,6 +507,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -488,6 +560,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -524,6 +600,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -531,6 +612,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
@@ -70,6 +70,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -82,7 +88,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -98,6 +116,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -122,6 +146,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			/* I2S_WS */
 
 			i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -139,8 +167,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -171,8 +209,18 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -259,8 +307,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -403,6 +463,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 				bias-pull-up;
@@ -428,6 +494,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -457,6 +529,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -495,6 +571,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -502,6 +583,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
@@ -70,6 +70,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -82,7 +88,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -98,6 +116,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -122,6 +146,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			/* I2S_WS */
 
 			i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -139,8 +167,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -171,8 +209,18 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -259,8 +307,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -403,6 +463,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 				bias-pull-up;
@@ -428,6 +494,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -457,6 +529,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -495,6 +571,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -502,6 +583,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
@@ -94,6 +94,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -102,6 +108,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -126,6 +138,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -134,6 +152,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -178,6 +202,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -211,6 +239,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -223,6 +256,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -268,6 +306,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -280,6 +323,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -416,8 +464,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -584,6 +644,10 @@
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
@@ -618,6 +682,10 @@
 
 			tim15_ch2_pwm_pc2: tim15_ch2_pwm_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+			};
+
+			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
@@ -656,6 +724,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -703,6 +777,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -768,6 +848,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -846,6 +930,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -868,6 +957,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071rbix-pinctrl.dtsi
@@ -94,6 +94,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -102,6 +108,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -126,6 +138,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -134,6 +152,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -178,6 +202,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -211,6 +239,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -223,6 +256,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -268,6 +306,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -280,6 +323,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -416,8 +464,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -584,6 +644,10 @@
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
@@ -618,6 +682,10 @@
 
 			tim15_ch2_pwm_pc2: tim15_ch2_pwm_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+			};
+
+			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
@@ -656,6 +724,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -703,6 +777,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -768,6 +848,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -846,6 +930,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -868,6 +957,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
@@ -86,6 +86,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -94,6 +100,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -118,6 +130,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -126,6 +144,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -166,6 +190,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -191,6 +219,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -198,6 +231,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -238,6 +276,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -245,6 +288,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -361,8 +409,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -489,6 +549,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
@@ -515,6 +579,10 @@
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
+			};
+
+			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
@@ -553,6 +621,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -600,6 +674,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -665,6 +745,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -709,6 +793,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -721,6 +810,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081cbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbux-pinctrl.dtsi
@@ -86,6 +86,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -94,6 +100,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -118,6 +130,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -126,6 +144,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -166,6 +190,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -191,6 +219,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -198,6 +231,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -238,6 +276,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -245,6 +288,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -361,8 +409,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -489,6 +549,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
@@ -515,6 +579,10 @@
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
+			};
+
+			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
@@ -553,6 +621,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -600,6 +674,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -665,6 +745,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -709,6 +793,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -721,6 +810,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
@@ -64,6 +64,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -76,10 +82,28 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -102,6 +126,10 @@
 
 			i2s1_sd_pa7: i2s1_sd_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
+			};
+
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
 			};
 
 			i2s1_sd_pb5: i2s1_sd_pb5 {
@@ -129,8 +157,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -151,6 +189,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -158,6 +201,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -218,6 +266,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -328,6 +388,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 				bias-pull-up;
@@ -347,6 +413,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -384,6 +456,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -411,6 +487,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -418,6 +499,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081gbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbux-pinctrl.dtsi
@@ -64,6 +64,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -76,10 +82,28 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -108,6 +132,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -133,6 +161,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -140,6 +173,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -160,6 +198,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -167,6 +210,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -232,6 +280,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -362,6 +422,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -387,6 +453,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -430,6 +502,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -457,6 +533,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -464,6 +545,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
@@ -60,6 +60,12 @@
 
 			/* I2C_SCL */
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -72,10 +78,28 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -100,6 +124,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			/* I2S_WS */
 
 			i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -117,8 +145,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -144,8 +182,18 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -216,6 +264,18 @@
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -342,6 +402,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 				bias-pull-up;
@@ -368,6 +434,12 @@
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 				bias-pull-up;
@@ -384,6 +456,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
@@ -409,6 +485,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -416,6 +497,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
@@ -74,6 +74,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -86,7 +92,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -102,6 +120,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -130,6 +154,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -155,6 +183,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -162,6 +195,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -192,6 +230,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -199,6 +242,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -280,8 +328,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -416,6 +476,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -441,6 +507,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -488,6 +560,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -524,6 +600,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -531,6 +612,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
@@ -70,6 +70,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -82,7 +88,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -98,6 +116,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -122,6 +146,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			/* I2S_WS */
 
 			i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -139,8 +167,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -171,8 +209,18 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -259,8 +307,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -403,6 +463,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 				bias-pull-up;
@@ -428,6 +494,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -457,6 +529,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -495,6 +571,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -502,6 +583,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081kbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbux-pinctrl.dtsi
@@ -74,6 +74,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -86,7 +92,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -102,6 +120,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -130,6 +154,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -155,6 +183,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -162,6 +195,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -192,6 +230,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -199,6 +242,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -280,8 +328,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -416,6 +476,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart1_cts_pb4: usart1_cts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 				bias-pull-up;
@@ -441,6 +507,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -488,6 +560,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+			};
+
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -524,6 +600,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -531,6 +612,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
@@ -70,6 +70,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -82,7 +88,19 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
+
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -98,6 +116,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -122,6 +146,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			/* I2S_WS */
 
 			i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -139,8 +167,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -171,8 +209,18 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -259,8 +307,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -403,6 +463,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 				bias-pull-up;
@@ -428,6 +494,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -457,6 +529,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -495,6 +571,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -502,6 +583,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbix-pinctrl.dtsi
@@ -94,6 +94,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -102,6 +108,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -126,6 +138,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -134,6 +152,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -178,6 +202,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -211,6 +239,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -223,6 +256,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -268,6 +306,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -280,6 +323,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -416,8 +464,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -584,6 +644,10 @@
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
@@ -618,6 +682,10 @@
 
 			tim15_ch2_pwm_pc2: tim15_ch2_pwm_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+			};
+
+			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
@@ -656,6 +724,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -703,6 +777,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -768,6 +848,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -846,6 +930,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -868,6 +957,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
@@ -94,6 +94,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pa9: i2c1_scl_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -102,6 +108,12 @@
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_scl_pa11: i2c2_scl_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -126,6 +138,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_sda_pa10: i2c1_sda_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -134,6 +152,12 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pa12: i2c2_sda_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -178,6 +202,10 @@
 				pinmux = <STM32_PINMUX('A', 7, AF0)>;
 			};
 
+			i2s1_sd_pa12: i2s1_sd_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+			};
+
 			i2s1_sd_pb5: i2s1_sd_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 			};
@@ -211,6 +239,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pa11: spi1_miso_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pb4: spi1_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF0)>;
 				bias-pull-down;
@@ -223,6 +256,11 @@
 
 			spi2_miso_pa3: spi2_miso_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pa9: spi2_miso_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
 
@@ -268,6 +306,11 @@
 				bias-pull-down;
 			};
 
+			spi1_mosi_pa12: spi1_mosi_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF0)>;
+				bias-pull-down;
+			};
+
 			spi1_mosi_pb5: spi1_mosi_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF0)>;
 				bias-pull-down;
@@ -280,6 +323,11 @@
 
 			spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pa10: spi2_mosi_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -416,8 +464,20 @@
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF2)>;
+			};
+
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF2)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -584,6 +644,10 @@
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
+			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
@@ -618,6 +682,10 @@
 
 			tim15_ch2_pwm_pc2: tim15_ch2_pwm_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+			};
+
+			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
@@ -656,6 +724,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -703,6 +777,12 @@
 			};
 
 			/* UART_RTS / USART_RTS / LPUART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
@@ -768,6 +848,10 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			usart1_rx_pa10: usart1_rx_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -846,6 +930,11 @@
 				bias-pull-up;
 			};
 
+			usart1_tx_pa9: usart1_tx_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF1)>;
+				bias-pull-up;
+			};
+
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
 				bias-pull-up;
@@ -868,6 +957,11 @@
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -84,6 +88,10 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -98,6 +106,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -120,6 +132,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -162,6 +180,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -172,6 +196,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -196,6 +224,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -277,6 +309,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -301,6 +338,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -365,6 +407,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -463,6 +509,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -509,6 +559,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -561,6 +615,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -669,6 +727,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -88,6 +92,10 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -102,6 +110,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -124,6 +136,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -172,6 +190,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -188,6 +212,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -216,6 +244,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -302,6 +334,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -326,6 +363,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -395,6 +437,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -497,6 +543,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -543,6 +593,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -595,6 +649,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -715,6 +773,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -88,6 +92,10 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -102,6 +110,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -124,6 +136,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -172,6 +190,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -188,6 +212,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -212,6 +240,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -298,6 +330,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -322,6 +359,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -386,6 +428,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -488,6 +534,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -534,6 +584,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -586,6 +640,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -702,6 +760,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
@@ -32,6 +32,10 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -70,6 +78,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -88,6 +100,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -124,6 +142,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -131,6 +155,10 @@
 			};
 
 			/* I2S_CK */
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -147,6 +175,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
@@ -212,6 +244,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -231,6 +268,11 @@
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -271,6 +313,10 @@
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -357,6 +403,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
@@ -387,6 +437,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -431,6 +485,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */

--- a/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
@@ -32,6 +32,10 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -70,6 +78,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -88,6 +100,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -124,6 +142,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -131,6 +155,10 @@
 			};
 
 			/* I2S_CK */
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -147,6 +175,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
@@ -212,6 +244,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -231,6 +268,11 @@
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -271,6 +313,10 @@
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -357,6 +403,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
@@ -387,6 +437,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -431,6 +485,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */

--- a/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -138,6 +146,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -168,6 +180,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -222,6 +240,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -244,6 +268,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -276,6 +304,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -367,6 +399,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -391,6 +428,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -514,6 +556,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -626,6 +672,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -672,6 +722,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -724,6 +778,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -888,6 +946,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -138,6 +146,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -160,6 +172,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -214,6 +232,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -236,6 +260,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -268,6 +296,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -359,6 +391,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -383,6 +420,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -472,6 +514,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -586,6 +632,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -632,6 +682,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -684,6 +738,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -840,6 +898,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -138,6 +146,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -160,6 +172,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -214,6 +232,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -236,6 +260,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -268,6 +296,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -359,6 +391,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -383,6 +420,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -472,6 +514,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -586,6 +632,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -632,6 +682,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -684,6 +738,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -840,6 +898,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -138,6 +146,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -168,6 +180,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -222,6 +240,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -244,6 +268,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -276,6 +304,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -372,6 +404,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -396,6 +433,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -527,6 +569,10 @@
 
 			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -673,6 +719,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -745,6 +795,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -803,6 +857,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -999,6 +1057,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -84,6 +88,10 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -98,6 +106,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -120,6 +132,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -162,6 +180,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -172,6 +196,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -196,6 +224,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -277,6 +309,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -301,6 +338,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -365,6 +407,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -463,6 +509,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -509,6 +559,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -561,6 +615,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -669,6 +727,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g441cbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbux-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -88,6 +92,10 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -102,6 +110,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -124,6 +136,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -172,6 +190,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -188,6 +212,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -216,6 +244,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -302,6 +334,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -326,6 +363,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -395,6 +437,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -497,6 +543,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -543,6 +593,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -595,6 +649,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -715,6 +773,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -88,6 +92,10 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -102,6 +110,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -124,6 +136,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -172,6 +190,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -188,6 +212,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -212,6 +240,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -298,6 +330,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -322,6 +359,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -386,6 +428,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -488,6 +534,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -534,6 +584,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -586,6 +640,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -702,6 +760,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
@@ -32,6 +32,10 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -70,6 +78,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -88,6 +100,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -124,6 +142,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -131,6 +155,10 @@
 			};
 
 			/* I2S_CK */
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -147,6 +175,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
@@ -212,6 +244,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -231,6 +268,11 @@
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -271,6 +313,10 @@
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -357,6 +403,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
@@ -387,6 +437,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -431,6 +485,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */

--- a/dts/st/g4/stm32g441kbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbux-pinctrl.dtsi
@@ -32,6 +32,10 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -56,6 +60,10 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -70,6 +78,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -88,6 +100,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -124,6 +142,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -131,6 +155,10 @@
 			};
 
 			/* I2S_CK */
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
@@ -147,6 +175,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
@@ -212,6 +244,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -231,6 +268,11 @@
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -271,6 +313,10 @@
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -357,6 +403,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
@@ -387,6 +437,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -431,6 +485,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */

--- a/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -138,6 +146,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -168,6 +180,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -222,6 +240,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -244,6 +268,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -276,6 +304,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -367,6 +399,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -391,6 +428,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -514,6 +556,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -626,6 +672,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -672,6 +722,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -724,6 +778,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -888,6 +946,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g441rbix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbix-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -138,6 +146,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -160,6 +172,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -214,6 +232,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -236,6 +260,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -268,6 +296,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -359,6 +391,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -383,6 +420,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -472,6 +514,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -586,6 +632,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -632,6 +682,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -684,6 +738,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -840,6 +898,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -138,6 +146,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -160,6 +172,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -214,6 +232,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -236,6 +260,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -268,6 +296,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -359,6 +391,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -383,6 +420,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -472,6 +514,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -586,6 +632,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -632,6 +682,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -684,6 +738,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -840,6 +898,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -138,6 +146,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -168,6 +180,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -222,6 +240,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -244,6 +268,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -276,6 +304,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -372,6 +404,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -396,6 +433,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -527,6 +569,10 @@
 
 			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -673,6 +719,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -745,6 +795,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -803,6 +857,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -999,6 +1057,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -84,6 +88,10 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			adc3_in12_pb0: adc3_in12_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -110,6 +118,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -148,6 +160,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -196,6 +214,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -212,6 +236,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -236,6 +264,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -317,6 +349,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -341,6 +378,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -405,6 +447,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -503,6 +549,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -571,6 +621,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -621,6 +675,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -729,6 +787,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -88,6 +92,10 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			adc3_in12_pb0: adc3_in12_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -114,6 +122,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -152,6 +164,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -212,6 +230,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -234,6 +258,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -262,6 +290,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -348,6 +380,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -372,6 +409,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -441,6 +483,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -543,6 +589,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -611,6 +661,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -661,6 +715,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -781,6 +839,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -184,6 +192,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -228,6 +240,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -294,6 +312,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -330,6 +354,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -360,6 +388,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -461,6 +493,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -490,6 +527,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -618,6 +660,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -730,6 +776,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -810,6 +860,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -860,6 +914,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1036,6 +1094,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -188,6 +196,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -232,6 +244,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -298,6 +316,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -334,6 +358,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -364,6 +392,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -465,6 +497,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -494,6 +531,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -622,6 +664,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -734,6 +780,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -814,6 +864,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -864,6 +918,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1046,6 +1104,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -200,6 +208,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -244,6 +256,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -340,6 +358,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -400,6 +424,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -430,6 +458,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -561,6 +593,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -605,6 +642,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -753,6 +795,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -897,6 +943,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1025,6 +1075,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1083,6 +1137,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1313,6 +1371,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			adc3_in12_pb0: adc3_in12_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -150,6 +158,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -188,6 +200,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -254,6 +272,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -290,6 +314,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -320,6 +348,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -411,6 +443,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -435,6 +472,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -524,6 +566,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -638,6 +684,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -710,6 +760,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -760,6 +814,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -928,6 +986,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -200,6 +208,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -244,6 +256,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -310,6 +328,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -346,6 +370,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -376,6 +404,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -492,6 +524,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -531,6 +568,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -672,6 +714,10 @@
 
 			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -818,6 +864,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -926,6 +976,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -984,6 +1038,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1192,6 +1250,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -200,6 +208,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -244,6 +256,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -310,6 +328,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -346,6 +370,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -376,6 +404,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -492,6 +524,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -531,6 +568,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -672,6 +714,10 @@
 
 			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -818,6 +864,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -926,6 +976,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -984,6 +1038,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1192,6 +1250,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -200,6 +208,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -244,6 +256,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -310,6 +328,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -346,6 +370,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -376,6 +404,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -492,6 +524,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -531,6 +568,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -672,6 +714,10 @@
 
 			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -818,6 +864,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -926,6 +976,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -984,6 +1038,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1192,6 +1250,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -82,6 +86,10 @@
 
 			adc2_in15_pb15: adc2_in15_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -134,6 +142,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -192,6 +204,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa9: i2c2_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-up;
@@ -236,6 +254,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -252,6 +276,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -276,6 +304,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -357,6 +389,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -381,6 +418,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -449,6 +491,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -547,6 +593,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -615,6 +665,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -665,6 +719,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -773,6 +831,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -86,6 +90,10 @@
 
 			adc2_in5_pc4: adc2_in5_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -140,6 +148,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF9)>;
 			};
@@ -192,6 +204,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -252,6 +270,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -274,6 +298,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -302,6 +330,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -388,6 +420,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -412,6 +449,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -485,6 +527,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -587,6 +633,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -655,6 +705,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -705,6 +759,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -825,6 +883,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -272,6 +280,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -332,6 +344,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -398,6 +416,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -434,6 +458,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -464,6 +492,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -565,6 +597,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -594,6 +631,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -734,6 +776,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -846,6 +892,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -926,6 +976,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -976,6 +1030,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1152,6 +1210,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -284,6 +292,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -344,6 +356,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -410,6 +428,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -446,6 +470,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -476,6 +504,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -577,6 +609,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -606,6 +643,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -746,6 +788,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -858,6 +904,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -938,6 +988,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -988,6 +1042,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1170,6 +1228,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -476,6 +494,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -536,6 +560,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -566,6 +594,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -697,6 +729,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -741,6 +778,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -977,6 +1019,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -1121,6 +1167,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1249,6 +1299,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1307,6 +1361,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1537,6 +1595,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			adc3_in12_pb0: adc3_in12_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -174,6 +182,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -228,6 +240,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -294,6 +312,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -330,6 +354,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -360,6 +388,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -451,6 +483,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -475,6 +512,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -576,6 +618,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -690,6 +736,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -762,6 +812,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -812,6 +866,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -980,6 +1038,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -82,6 +86,10 @@
 
 			adc2_in15_pb15: adc2_in15_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -134,6 +142,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -192,6 +204,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa9: i2c2_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-up;
@@ -236,6 +254,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -252,6 +276,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -276,6 +304,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -357,6 +389,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -381,6 +418,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -449,6 +491,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -547,6 +593,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -615,6 +665,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -665,6 +719,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -773,6 +831,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -86,6 +90,10 @@
 
 			adc2_in5_pc4: adc2_in5_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -140,6 +148,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF9)>;
 			};
@@ -192,6 +204,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -252,6 +270,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -274,6 +298,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -302,6 +330,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -388,6 +420,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -412,6 +449,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -485,6 +527,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -587,6 +633,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -655,6 +705,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -705,6 +759,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -825,6 +883,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -272,6 +280,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -332,6 +344,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -398,6 +416,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -434,6 +458,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -464,6 +492,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -565,6 +597,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -594,6 +631,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -734,6 +776,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -846,6 +892,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -926,6 +976,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -976,6 +1030,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1152,6 +1210,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -284,6 +292,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -344,6 +356,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -410,6 +428,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -446,6 +470,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -476,6 +504,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -577,6 +609,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -606,6 +643,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -746,6 +788,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -858,6 +904,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -938,6 +988,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -988,6 +1042,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1170,6 +1228,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -476,6 +494,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -536,6 +560,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -566,6 +594,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -697,6 +729,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -741,6 +778,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -977,6 +1019,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -1121,6 +1167,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1249,6 +1299,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1307,6 +1361,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1537,6 +1595,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			adc3_in12_pb0: adc3_in12_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -174,6 +182,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -228,6 +240,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -294,6 +312,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -330,6 +354,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -360,6 +388,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -451,6 +483,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -475,6 +512,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -576,6 +618,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -690,6 +736,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -762,6 +812,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -812,6 +866,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -980,6 +1038,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -82,6 +86,10 @@
 
 			adc2_in15_pb15: adc2_in15_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -134,6 +142,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -192,6 +204,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa9: i2c2_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-up;
@@ -236,6 +254,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -252,6 +276,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -276,6 +304,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -357,6 +389,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -381,6 +418,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -449,6 +491,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -547,6 +593,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -615,6 +665,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -665,6 +719,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -773,6 +831,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -86,6 +90,10 @@
 
 			adc2_in5_pc4: adc2_in5_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -140,6 +148,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF9)>;
 			};
@@ -192,6 +204,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -252,6 +270,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -274,6 +298,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -302,6 +330,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -388,6 +420,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -412,6 +449,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -485,6 +527,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -587,6 +633,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -655,6 +705,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -705,6 +759,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -825,6 +883,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -272,6 +280,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -332,6 +344,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -398,6 +416,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -434,6 +458,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -464,6 +492,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -565,6 +597,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -594,6 +631,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -734,6 +776,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -846,6 +892,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -926,6 +976,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -976,6 +1030,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1152,6 +1210,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -284,6 +292,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -344,6 +356,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -410,6 +428,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -446,6 +470,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -476,6 +504,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -577,6 +609,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -606,6 +643,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -746,6 +788,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -858,6 +904,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -938,6 +988,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -988,6 +1042,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1170,6 +1228,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -476,6 +494,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -536,6 +560,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -566,6 +594,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -697,6 +729,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -741,6 +778,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -977,6 +1019,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -1121,6 +1167,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1249,6 +1299,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1307,6 +1361,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1537,6 +1595,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			adc3_in12_pb0: adc3_in12_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -174,6 +182,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -228,6 +240,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -294,6 +312,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -330,6 +354,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -360,6 +388,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -451,6 +483,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -475,6 +512,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -576,6 +618,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -690,6 +736,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -762,6 +812,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -812,6 +866,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -980,6 +1038,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g483veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483veix-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -82,6 +86,10 @@
 
 			adc2_in15_pb15: adc2_in15_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -134,6 +142,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -192,6 +204,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c2_scl_pa9: i2c2_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-up;
@@ -236,6 +254,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -252,6 +276,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -276,6 +304,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -357,6 +389,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -381,6 +418,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -449,6 +491,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -547,6 +593,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -615,6 +665,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -665,6 +719,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -773,6 +831,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -48,6 +48,10 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -86,6 +90,10 @@
 
 			adc2_in5_pc4: adc2_in5_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -140,6 +148,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF9)>;
 			};
@@ -192,6 +204,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -252,6 +270,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -274,6 +298,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -302,6 +330,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -388,6 +420,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -412,6 +449,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -485,6 +527,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -587,6 +633,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -655,6 +705,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -705,6 +759,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -825,6 +883,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -272,6 +280,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -332,6 +344,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -398,6 +416,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -434,6 +458,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -464,6 +492,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -565,6 +597,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -594,6 +631,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -734,6 +776,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -846,6 +892,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -926,6 +976,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -976,6 +1030,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1152,6 +1210,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -284,6 +292,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -344,6 +356,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -410,6 +428,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -446,6 +470,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -476,6 +504,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -577,6 +609,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -606,6 +643,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -746,6 +788,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -858,6 +904,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -938,6 +988,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -988,6 +1042,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1170,6 +1228,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -476,6 +494,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -536,6 +560,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -566,6 +594,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -697,6 +729,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -741,6 +778,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -977,6 +1019,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -1121,6 +1167,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1249,6 +1299,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1307,6 +1361,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1537,6 +1595,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -124,6 +128,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			adc3_in12_pb0: adc3_in12_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
@@ -174,6 +182,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			fdcan2_rx_pb5: fdcan2_rx_pb5 {
@@ -228,6 +240,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -294,6 +312,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -330,6 +354,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -360,6 +388,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -451,6 +483,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -475,6 +512,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -576,6 +618,10 @@
 
 			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -690,6 +736,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -762,6 +812,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
@@ -812,6 +866,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -980,6 +1038,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g484veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484veix-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -122,6 +126,10 @@
 
 			adc2_in11_pc5: adc2_in11_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
 			adc3_in12_pb0: adc3_in12_pb0 {
@@ -320,6 +328,10 @@
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
 			};
 
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+			};
+
 			fdcan1_rx_pd0: fdcan1_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF9)>;
 			};
@@ -380,6 +392,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -446,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -482,6 +506,10 @@
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 			};
@@ -512,6 +540,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -628,6 +660,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -667,6 +704,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -854,6 +896,10 @@
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
+			};
+
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
@@ -998,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -1106,6 +1156,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+			};
+
 			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
@@ -1164,6 +1218,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -1372,6 +1430,10 @@
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
@@ -64,6 +64,10 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			adc1_in10_pf0: adc1_in10_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
 			adc2_in1_pa0: adc2_in1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
@@ -120,6 +124,10 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			adc2_in10_pf1: adc2_in10_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -134,6 +142,10 @@
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+			};
+
+			fdcan1_rx_pb8: fdcan1_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
 			};
 
 			/* FDCAN_TX */
@@ -156,6 +168,12 @@
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_scl_pb8: i2c1_scl_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -198,6 +216,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pf0: i2c2_sda_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pb5: i2c3_sda_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
 				bias-pull-up;
@@ -208,6 +232,10 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+			};
+
+			i2s2_ck_pf1: i2s2_ck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
@@ -232,6 +260,10 @@
 
 			i2s2_ws_pb12: i2s2_ws_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF5)>;
+			};
+
+			i2s2_ws_pf0: i2s2_ws_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
@@ -313,6 +345,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_pf0: spi2_nss_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 				bias-pull-up;
@@ -337,6 +374,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi2_sck_pf1: spi2_sck_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -417,6 +459,10 @@
 
 			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
@@ -523,6 +569,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
+			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF2)>;
+			};
+
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
@@ -569,6 +619,10 @@
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
+			};
+
+			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
@@ -621,6 +675,10 @@
 
 			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
+			};
+
+			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
 			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
@@ -741,6 +799,10 @@
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+			};
+
+			usart3_rx_pb8: usart3_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -468,6 +480,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -496,6 +512,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -506,12 +526,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -530,10 +558,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -547,8 +584,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -574,6 +621,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +658,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -676,6 +733,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -683,6 +745,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -703,6 +770,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -731,6 +803,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -740,6 +817,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -778,6 +860,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -800,6 +887,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -898,6 +990,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -932,6 +1032,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1262,6 +1366,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1390,6 +1500,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1501,6 +1615,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -611,6 +658,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -640,6 +692,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -715,6 +772,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -722,6 +784,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -742,6 +809,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -775,6 +847,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -784,6 +861,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -822,6 +904,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -854,6 +941,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -976,6 +1068,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1018,6 +1118,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1396,6 +1500,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1532,6 +1642,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1652,6 +1766,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -573,6 +610,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -603,6 +645,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +752,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +764,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +789,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +822,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +836,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +879,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +911,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1014,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1064,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1414,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1556,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1676,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -573,6 +610,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -603,6 +645,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +752,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +764,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +789,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +822,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +836,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +879,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +911,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1014,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1064,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1414,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1556,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1676,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -320,6 +332,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s2_ck_pa9: i2s2_ck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
@@ -340,6 +356,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -350,8 +370,16 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -366,6 +394,10 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -373,8 +405,23 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -395,6 +442,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -422,6 +474,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -472,8 +529,18 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -492,6 +559,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi4_nss_pe4: spi4_nss_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF5)>;
 				bias-pull-up;
@@ -507,10 +579,20 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -539,6 +621,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -556,6 +643,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +741,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -683,6 +783,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -943,6 +1047,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1049,6 +1159,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1151,6 +1265,16 @@
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -320,6 +332,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s2_ck_pa9: i2s2_ck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
@@ -340,6 +356,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -350,8 +370,16 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -366,6 +394,10 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -373,8 +405,23 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -395,6 +442,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -422,6 +474,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -472,8 +529,18 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -492,6 +559,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi4_nss_pe4: spi4_nss_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF5)>;
 				bias-pull-up;
@@ -507,10 +579,20 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -539,6 +621,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -556,6 +643,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +741,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -683,6 +783,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -943,6 +1047,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1049,6 +1159,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1151,6 +1265,16 @@
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -509,6 +556,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -541,6 +593,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +663,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -613,6 +675,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -628,6 +695,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -651,6 +723,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -660,6 +737,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -693,6 +775,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -715,6 +802,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -813,6 +905,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -847,6 +947,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1149,6 +1253,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1277,6 +1387,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1388,6 +1502,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -468,6 +480,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -496,6 +512,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -506,12 +526,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -530,10 +558,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -547,8 +584,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -574,6 +621,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +658,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -676,6 +733,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -683,6 +745,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -703,6 +770,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -731,6 +803,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -740,6 +817,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -778,6 +860,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -800,6 +887,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -898,6 +990,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -932,6 +1032,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1262,6 +1366,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1390,6 +1500,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1501,6 +1615,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -611,6 +658,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -640,6 +692,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -715,6 +772,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -722,6 +784,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -742,6 +809,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -775,6 +847,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -784,6 +861,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -822,6 +904,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -854,6 +941,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -976,6 +1068,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1018,6 +1118,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1396,6 +1500,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1532,6 +1642,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1652,6 +1766,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -611,6 +658,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -640,6 +692,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -715,6 +772,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -722,6 +784,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -742,6 +809,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -775,6 +847,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -784,6 +861,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -822,6 +904,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -854,6 +941,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -976,6 +1068,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1018,6 +1118,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1396,6 +1500,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1532,6 +1642,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1652,6 +1766,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +653,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -635,6 +687,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +762,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +774,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +799,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +832,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +846,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +889,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +921,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1024,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1074,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1424,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1566,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1686,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +653,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -635,6 +687,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +762,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +774,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +799,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +832,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +846,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +889,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +921,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1024,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1074,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1424,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1566,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1686,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +653,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -635,6 +687,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +762,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +774,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +799,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +832,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +846,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +889,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +921,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1024,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1074,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1424,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1566,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1686,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +653,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -635,6 +687,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +762,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +774,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +799,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +832,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +846,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +889,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +921,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1024,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1074,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1424,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1566,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1686,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -320,6 +332,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s2_ck_pa9: i2s2_ck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
@@ -340,6 +356,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -350,8 +370,16 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -366,6 +394,10 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -373,8 +405,23 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -395,6 +442,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -422,6 +474,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -472,8 +529,18 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -492,6 +559,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi4_nss_pe4: spi4_nss_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF5)>;
 				bias-pull-up;
@@ -507,10 +579,20 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -539,6 +621,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -556,6 +643,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +741,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -683,6 +783,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -943,6 +1047,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1049,6 +1159,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1151,6 +1265,16 @@
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -320,6 +332,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s2_ck_pa9: i2s2_ck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
@@ -340,6 +356,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -350,8 +370,16 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -366,6 +394,10 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -373,8 +405,23 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -395,6 +442,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -422,6 +474,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -472,8 +529,18 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -492,6 +559,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi4_nss_pe4: spi4_nss_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF5)>;
 				bias-pull-up;
@@ -507,10 +579,20 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -539,6 +621,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -556,6 +643,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +741,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -683,6 +783,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -943,6 +1047,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1049,6 +1159,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1151,6 +1265,16 @@
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -320,6 +332,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s2_ck_pa9: i2s2_ck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
@@ -340,6 +356,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -350,8 +370,16 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -366,6 +394,10 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -373,8 +405,23 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -395,6 +442,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -422,6 +474,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -472,8 +529,18 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -492,6 +559,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi4_nss_pe4: spi4_nss_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF5)>;
 				bias-pull-up;
@@ -507,10 +579,20 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -539,6 +621,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -556,6 +643,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +741,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -683,6 +783,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -943,6 +1047,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1049,6 +1159,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1151,6 +1265,16 @@
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -509,6 +556,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -541,6 +593,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +663,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -613,6 +675,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -628,6 +695,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -651,6 +723,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -660,6 +737,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -693,6 +775,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -715,6 +802,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -813,6 +905,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -847,6 +947,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1149,6 +1253,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1277,6 +1387,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1388,6 +1502,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -509,6 +556,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -541,6 +593,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +663,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -613,6 +675,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -628,6 +695,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -651,6 +723,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -660,6 +737,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -693,6 +775,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -715,6 +802,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -813,6 +905,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -847,6 +947,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1149,6 +1253,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1277,6 +1387,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1388,6 +1502,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -611,6 +658,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -640,6 +692,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -715,6 +772,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -722,6 +784,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -742,6 +809,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -775,6 +847,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -784,6 +861,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -822,6 +904,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -854,6 +941,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -976,6 +1068,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1018,6 +1118,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1396,6 +1500,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1532,6 +1642,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1652,6 +1766,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -611,6 +658,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -640,6 +692,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -715,6 +772,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -722,6 +784,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -742,6 +809,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -775,6 +847,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -784,6 +861,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -822,6 +904,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -854,6 +941,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -976,6 +1068,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1018,6 +1118,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1396,6 +1500,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1532,6 +1642,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1652,6 +1766,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -528,6 +564,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -552,6 +592,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -562,12 +606,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -582,10 +634,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -601,6 +662,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -631,6 +697,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -733,6 +804,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -740,6 +816,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -755,6 +836,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -783,6 +869,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -792,6 +883,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -825,6 +921,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -852,6 +953,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -950,6 +1056,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -992,6 +1106,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1318,6 +1436,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1450,6 +1574,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1566,6 +1694,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -517,6 +564,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -546,6 +598,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -616,6 +673,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -623,6 +685,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -638,6 +705,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -666,6 +738,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -675,6 +752,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -708,6 +790,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -735,6 +822,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -857,6 +949,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -891,6 +991,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1217,6 +1321,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1345,6 +1455,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1460,6 +1574,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -528,6 +564,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -552,6 +592,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -562,12 +606,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -582,10 +634,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -601,6 +662,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -631,6 +697,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -733,6 +804,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -740,6 +816,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -755,6 +836,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -783,6 +869,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -792,6 +883,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -825,6 +921,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -852,6 +953,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -950,6 +1056,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -992,6 +1106,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1318,6 +1436,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1450,6 +1574,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1566,6 +1694,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -517,6 +564,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -546,6 +598,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -616,6 +673,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -623,6 +685,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -638,6 +705,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -666,6 +738,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -675,6 +752,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -708,6 +790,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -735,6 +822,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -857,6 +949,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -891,6 +991,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1217,6 +1321,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1345,6 +1455,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1460,6 +1574,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -184,6 +184,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inn4_pf6: adc3_inn4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -376,6 +388,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -400,6 +416,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -410,12 +430,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -430,10 +458,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -444,6 +481,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -469,6 +516,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -501,6 +553,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -566,6 +623,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -573,6 +635,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -588,6 +655,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -611,6 +683,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -620,6 +697,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -653,6 +735,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -675,6 +762,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -773,6 +865,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -807,6 +907,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1103,6 +1207,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1231,6 +1341,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1342,6 +1456,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -184,6 +184,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inn4_pf6: adc3_inn4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -376,6 +388,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -400,6 +416,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -410,12 +430,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -430,10 +458,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -444,6 +481,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -469,6 +516,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -501,6 +553,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -566,6 +623,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -573,6 +635,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -588,6 +655,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -611,6 +683,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -620,6 +697,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -653,6 +735,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -675,6 +762,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -773,6 +865,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -807,6 +907,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1103,6 +1207,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1231,6 +1341,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1342,6 +1456,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -509,6 +556,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -541,6 +593,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +663,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -613,6 +675,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -628,6 +695,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -651,6 +723,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -660,6 +737,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -693,6 +775,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -715,6 +802,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -813,6 +905,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -847,6 +947,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1149,6 +1253,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1277,6 +1387,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1388,6 +1502,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +653,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -635,6 +687,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +762,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +774,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +799,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +832,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +846,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +889,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +921,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1024,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1074,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1424,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1566,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1686,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +653,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -635,6 +687,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +762,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +774,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +799,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +832,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +846,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +889,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +921,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1024,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1074,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1424,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1566,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1686,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -509,6 +556,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -541,6 +593,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +663,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -613,6 +675,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -628,6 +695,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -651,6 +723,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -660,6 +737,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -693,6 +775,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -715,6 +802,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -813,6 +905,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -847,6 +947,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1149,6 +1253,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1277,6 +1387,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1388,6 +1502,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -509,6 +556,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -541,6 +593,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +663,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -613,6 +675,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -628,6 +695,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -651,6 +723,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -660,6 +737,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -693,6 +775,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -715,6 +802,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -813,6 +905,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -847,6 +947,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1149,6 +1253,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1277,6 +1387,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1388,6 +1502,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -384,6 +396,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s2_ck_pa9: i2s2_ck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
@@ -404,6 +420,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -414,8 +434,16 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -430,6 +458,10 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -437,8 +469,23 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -459,6 +506,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -486,6 +538,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -536,8 +593,18 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -556,6 +623,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi4_nss_pe4: spi4_nss_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF5)>;
 				bias-pull-up;
@@ -571,6 +643,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -580,6 +657,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -608,6 +690,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -625,6 +712,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -718,6 +810,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -752,6 +852,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1018,6 +1122,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1130,6 +1240,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1232,6 +1346,16 @@
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +653,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -635,6 +687,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +762,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +774,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +799,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +832,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +846,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +889,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +921,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1024,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1074,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1424,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1566,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1686,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -573,6 +610,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -603,6 +645,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +752,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +764,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +789,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +822,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +836,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +879,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +911,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1014,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1064,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1414,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1556,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1676,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -320,6 +332,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s2_ck_pa9: i2s2_ck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
@@ -340,6 +356,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -350,8 +370,16 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -366,6 +394,10 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -373,8 +405,23 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -395,6 +442,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -422,6 +474,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -472,8 +529,18 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -492,6 +559,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi4_nss_pe4: spi4_nss_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF5)>;
 				bias-pull-up;
@@ -507,10 +579,20 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -539,6 +621,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -556,6 +643,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +741,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -683,6 +783,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -943,6 +1047,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1049,6 +1159,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1151,6 +1265,16 @@
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -509,6 +556,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -541,6 +593,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +663,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -613,6 +675,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -628,6 +695,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -651,6 +723,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -660,6 +737,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -693,6 +775,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -715,6 +802,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -813,6 +905,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -847,6 +947,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1149,6 +1253,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1277,6 +1387,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1388,6 +1502,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -468,6 +480,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -496,6 +512,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -506,12 +526,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -530,10 +558,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -547,8 +584,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -574,6 +621,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +658,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -676,6 +733,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -683,6 +745,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -703,6 +770,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -731,6 +803,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -740,6 +817,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -778,6 +860,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -800,6 +887,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -898,6 +990,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -932,6 +1032,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1262,6 +1366,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1390,6 +1500,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1501,6 +1615,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -611,6 +658,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -640,6 +692,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -715,6 +772,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -722,6 +784,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -742,6 +809,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -775,6 +847,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -784,6 +861,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -822,6 +904,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -854,6 +941,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -976,6 +1068,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1018,6 +1118,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1396,6 +1500,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1532,6 +1642,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1652,6 +1766,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +653,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -635,6 +687,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +762,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +774,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +799,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +832,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +846,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +889,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +921,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1024,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1074,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1424,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1566,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1686,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +653,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -635,6 +687,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +762,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +774,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +799,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +832,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +846,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +889,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +921,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1024,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1074,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1424,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1566,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1686,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -320,6 +332,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s2_ck_pa9: i2s2_ck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
@@ -340,6 +356,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -350,8 +370,16 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -366,6 +394,10 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -373,8 +405,23 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -395,6 +442,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -422,6 +474,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -472,8 +529,18 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -492,6 +559,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi4_nss_pe4: spi4_nss_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF5)>;
 				bias-pull-up;
@@ -507,10 +579,20 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -539,6 +621,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -556,6 +643,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +741,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -683,6 +783,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -943,6 +1047,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1049,6 +1159,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1151,6 +1265,16 @@
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {
@@ -320,6 +332,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s2_ck_pa9: i2s2_ck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
@@ -340,6 +356,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -350,8 +370,16 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -366,6 +394,10 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -373,8 +405,23 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -395,6 +442,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -422,6 +474,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -472,8 +529,18 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -492,6 +559,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi4_nss_pe4: spi4_nss_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF5)>;
 				bias-pull-up;
@@ -507,10 +579,20 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -539,6 +621,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -556,6 +643,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +741,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -683,6 +783,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -943,6 +1047,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1049,6 +1159,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1151,6 +1265,16 @@
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -509,6 +556,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -541,6 +593,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +663,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -613,6 +675,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -628,6 +695,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -651,6 +723,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -660,6 +737,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -693,6 +775,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -715,6 +802,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -813,6 +905,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -847,6 +947,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1149,6 +1253,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1277,6 +1387,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1388,6 +1502,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -611,6 +658,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -640,6 +692,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -715,6 +772,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -722,6 +784,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -742,6 +809,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -775,6 +847,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -784,6 +861,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -822,6 +904,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -854,6 +941,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -976,6 +1068,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1018,6 +1118,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1396,6 +1500,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1532,6 +1642,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1652,6 +1766,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -528,6 +564,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -552,6 +592,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -562,12 +606,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -582,10 +634,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -601,6 +662,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -631,6 +697,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -733,6 +804,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -740,6 +816,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -755,6 +836,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -783,6 +869,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -792,6 +883,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -825,6 +921,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -852,6 +953,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -950,6 +1056,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -992,6 +1106,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1318,6 +1436,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1450,6 +1574,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1566,6 +1694,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -517,6 +564,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -546,6 +598,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -616,6 +673,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -623,6 +685,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -638,6 +705,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -666,6 +738,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -675,6 +752,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -708,6 +790,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -735,6 +822,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -857,6 +949,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -891,6 +991,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1217,6 +1321,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1345,6 +1455,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1460,6 +1574,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -184,6 +184,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inn4_pf6: adc3_inn4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -376,6 +388,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -400,6 +416,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -410,12 +430,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -430,10 +458,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -444,6 +481,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -469,6 +516,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -501,6 +553,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -566,6 +623,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -573,6 +635,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -588,6 +655,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -611,6 +683,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -620,6 +697,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -653,6 +735,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -675,6 +762,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -773,6 +865,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -807,6 +907,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1103,6 +1207,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1231,6 +1341,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1342,6 +1456,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -509,6 +556,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -541,6 +593,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +663,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -613,6 +675,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -628,6 +695,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -651,6 +723,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -660,6 +737,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -693,6 +775,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -715,6 +802,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -813,6 +905,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -847,6 +947,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1149,6 +1253,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1277,6 +1387,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1388,6 +1502,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -492,6 +504,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -520,6 +536,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -530,12 +550,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -554,10 +582,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -571,8 +608,18 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +653,11 @@
 				bias-pull-down;
 			};
 
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-down;
+			};
+
 			spi6_miso_pg12: spi6_miso_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF5)>;
 				bias-pull-down;
@@ -635,6 +687,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -705,6 +762,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -712,6 +774,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -732,6 +799,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -760,6 +832,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -769,6 +846,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -807,6 +889,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -834,6 +921,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +1024,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -974,6 +1074,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1320,6 +1424,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1456,6 +1566,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1572,6 +1686,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -416,6 +428,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -440,6 +456,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -450,12 +470,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -470,10 +498,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -484,6 +521,16 @@
 
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -509,6 +556,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -541,6 +593,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -606,6 +663,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -613,6 +675,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -628,6 +695,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -651,6 +723,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -660,6 +737,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -693,6 +775,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -715,6 +802,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -813,6 +905,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -847,6 +947,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1149,6 +1253,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1277,6 +1387,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1388,6 +1502,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			adc2_inn1_pa0: adc2_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp0_pa0: adc2_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc2_inp1_pa1: adc2_inp1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -234,6 +258,18 @@
 
 			adc3_inp12_pc2: adc3_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc3_inp5_pf3: adc3_inp5_pf3 {
@@ -532,6 +568,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s1_ck_pg11: i2s1_ck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
 			};
@@ -560,6 +600,10 @@
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -570,12 +614,20 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s1_ws_pg10: i2s1_ws_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 			};
 
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -594,10 +646,19 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -618,6 +679,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -653,6 +719,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -765,6 +836,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pg10: spi1_nss_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF5)>;
 				bias-pull-up;
@@ -772,6 +848,11 @@
 
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -792,6 +873,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -825,6 +911,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -834,6 +925,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -872,6 +968,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -904,6 +1005,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1132,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -1068,6 +1182,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1446,6 +1564,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1582,6 +1706,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1702,6 +1830,16 @@
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc3_inn1_pc2: adc3_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp0_pc2: adc3_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc3_inp1_pc3: adc3_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -384,6 +396,10 @@
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
+			i2s1_ck_pb3: i2s1_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+			};
+
 			i2s2_ck_pa9: i2s2_ck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
@@ -404,6 +420,10 @@
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
 			};
 
+			i2s3_ck_pb3: i2s3_ck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+			};
+
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 			};
@@ -414,8 +434,16 @@
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
 			};
 
+			i2s1_ws_pa15: i2s1_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 			i2s2_ws_pa11: i2s2_ws_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+			};
+
+			i2s2_ws_pb4: i2s2_ws_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 			};
 
 			i2s2_ws_pb9: i2s2_ws_pb9 {
@@ -430,6 +458,10 @@
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
 			};
 
+			i2s3_ws_pa15: i2s3_ws_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -437,8 +469,23 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -459,6 +506,11 @@
 
 			spi6_miso_pa6: spi6_miso_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
+				bias-pull-down;
+			};
+
+			spi6_miso_pb4: spi6_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-down;
 			};
 
@@ -486,6 +538,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -536,8 +593,18 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pa11: spi2_nss_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-up;
+			};
+
+			spi2_nss_pb4: spi2_nss_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
 				bias-pull-up;
 			};
 
@@ -556,6 +623,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi4_nss_pe4: spi4_nss_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF5)>;
 				bias-pull-up;
@@ -571,6 +643,11 @@
 				bias-pull-up;
 			};
 
+			spi6_nss_pa15: spi6_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+			};
+
 			spi6_nss_pg8: spi6_nss_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 				bias-pull-up;
@@ -580,6 +657,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -608,6 +690,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
 				slew-rate = "very-high-speed";
@@ -625,6 +712,11 @@
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi6_sck_pb3: spi6_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -718,6 +810,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -752,6 +852,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1018,6 +1122,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
 				bias-pull-up;
@@ -1130,6 +1240,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
 			};
 
+			uart7_rx_pb3: uart7_rx_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+			};
+
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
 			};
@@ -1232,6 +1346,16 @@
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pa15: uart7_tx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+				bias-pull-up;
+			};
+
+			uart7_tx_pb4: uart7_tx_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -162,6 +174,18 @@
 
 			adc2_inp12_pc2: adc2_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc2_inn12_pc3: adc2_inn12_pc3 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -132,6 +132,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			adc1_inn1_pa0: adc1_inn1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			adc1_inp0_pa0: adc1_inp0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -162,6 +174,18 @@
 
 			adc2_inp12_pc2: adc2_inp12_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			adc2_inn12_pc3: adc2_inn12_pc3 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -132,6 +132,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			adc2_inn1_pc2: adc2_inn1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp0_pc2: adc2_inp0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			adc2_inp1_pc3: adc2_inp1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};

--- a/dts/st/l0/stm32l010f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010f4px-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -133,6 +137,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -165,6 +173,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -187,12 +201,20 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -192,6 +196,10 @@
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -252,6 +260,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -292,6 +306,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
@@ -302,6 +320,10 @@
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -90,6 +94,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -99,6 +107,12 @@
 			};
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
@@ -116,8 +130,16 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {

--- a/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -159,6 +163,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -215,6 +223,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -243,6 +257,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
@@ -253,6 +271,10 @@
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -133,6 +137,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -165,6 +173,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -187,12 +201,20 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -129,6 +133,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -161,6 +169,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -183,12 +197,20 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {

--- a/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -178,6 +182,10 @@
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -238,6 +246,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -266,6 +280,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
@@ -276,6 +294,10 @@
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -192,6 +196,10 @@
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -252,6 +260,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -292,6 +306,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
@@ -302,6 +320,10 @@
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -203,6 +207,10 @@
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -263,6 +271,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -303,6 +317,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
@@ -313,6 +331,10 @@
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l021d4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021d4px-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -90,6 +94,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -99,6 +107,12 @@
 			};
 
 			/* UART_CTS / USART_CTS / LPUART_CTS */
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
@@ -116,8 +130,16 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {

--- a/dts/st/l0/stm32l021f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4px-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -133,6 +137,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -165,6 +173,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -187,12 +201,20 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -129,6 +133,10 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -161,6 +169,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -183,12 +197,20 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {

--- a/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -178,6 +182,10 @@
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -238,6 +246,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -266,6 +280,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
@@ -276,6 +294,10 @@
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -192,6 +196,10 @@
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -252,6 +260,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -292,6 +306,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
@@ -302,6 +320,10 @@
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -203,6 +207,10 @@
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -263,6 +271,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa7: usart2_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 				bias-pull-up;
@@ -303,6 +317,10 @@
 
 			/* UART_RX / USART_RX / LPUART_RX */
 
+			lpuart1_rx_pa0: lpuart1_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
 			};
@@ -313,6 +331,10 @@
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			usart2_rx_pa0: usart2_rx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF0)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {

--- a/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -133,6 +137,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -185,6 +193,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -103,6 +107,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -143,6 +151,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -138,6 +142,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -194,6 +202,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -148,6 +152,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -212,6 +220,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -162,6 +166,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -226,6 +234,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -168,6 +172,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -232,6 +240,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -133,6 +137,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -185,6 +193,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l041f6px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041f6px-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -103,6 +107,10 @@
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -143,6 +151,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -138,6 +142,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -194,6 +202,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -148,6 +152,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -212,6 +220,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -162,6 +166,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -226,6 +234,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -168,6 +172,10 @@
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -232,6 +240,12 @@
 
 			lpuart1_cts_pa6: lpuart1_cts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF4)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -218,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -310,6 +318,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -218,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -310,6 +318,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -242,6 +246,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -350,6 +358,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -242,6 +246,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -350,6 +358,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l100rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100rctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -432,6 +440,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -218,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -310,6 +318,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -218,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -310,6 +318,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -218,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -310,6 +318,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -218,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -310,6 +318,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151cctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -277,6 +281,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -349,6 +357,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -381,6 +393,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ccux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -277,6 +281,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -349,6 +357,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -381,6 +393,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qchx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -416,6 +420,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -544,6 +552,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -604,6 +616,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -416,6 +420,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -544,6 +552,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -604,6 +616,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qehx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -416,6 +420,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -544,6 +552,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -600,10 +612,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -238,6 +242,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -346,6 +354,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -238,6 +242,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -346,6 +354,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -242,6 +246,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -350,6 +358,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -242,6 +246,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -350,6 +358,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151retx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -306,6 +310,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -462,10 +470,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -306,6 +310,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -462,10 +470,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -306,6 +310,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -462,10 +470,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -306,6 +310,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -462,10 +470,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vchx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -572,6 +584,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -572,6 +584,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151veyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -420,6 +424,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -548,6 +556,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -608,6 +620,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -420,6 +424,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -548,6 +556,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -608,6 +620,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l151zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -420,6 +424,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -548,6 +556,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -604,10 +616,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -218,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -310,6 +318,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -218,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -310,6 +318,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -218,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -310,6 +318,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -218,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -310,6 +318,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152cctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -277,6 +281,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -349,6 +357,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -381,6 +393,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ccux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -277,6 +281,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -349,6 +357,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -381,6 +393,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qchx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -416,6 +420,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -544,6 +552,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -604,6 +616,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -416,6 +420,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -544,6 +552,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -604,6 +616,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qehx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -416,6 +420,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -544,6 +552,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -600,10 +612,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -238,6 +242,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -346,6 +354,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -238,6 +242,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -346,6 +354,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -242,6 +246,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -350,6 +358,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -242,6 +246,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -350,6 +358,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152retx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -306,6 +310,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -462,10 +470,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -306,6 +310,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -462,10 +470,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -306,6 +310,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -462,10 +470,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -306,6 +310,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -462,10 +470,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vchx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -572,6 +584,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -572,6 +584,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152veyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -420,6 +424,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -548,6 +556,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -608,6 +620,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -420,6 +424,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -548,6 +556,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -608,6 +620,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l152zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -420,6 +424,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -548,6 +556,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -604,10 +616,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -416,6 +420,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -544,6 +552,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -604,6 +616,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162retx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -324,6 +328,10 @@
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -412,6 +420,10 @@
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -444,6 +456,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vchx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -572,6 +584,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -572,6 +584,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162veyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -400,6 +404,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -528,6 +536,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -568,10 +580,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -420,6 +424,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -548,6 +556,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -608,6 +620,12 @@
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l1/stm32l162zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zetx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc_in0_pa0: adc_in0_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc_in1_pa1: adc_in1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -420,6 +424,10 @@
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -548,6 +556,10 @@
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -604,10 +616,20 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -163,6 +169,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -200,6 +211,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -224,6 +240,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -299,6 +320,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -357,6 +386,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -395,6 +430,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -403,6 +444,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -439,6 +486,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -163,6 +169,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -200,6 +211,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -224,6 +240,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -299,6 +320,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -357,6 +386,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -395,6 +430,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -403,6 +444,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -439,6 +486,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -163,6 +169,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -200,6 +211,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -224,6 +240,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -299,6 +320,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -357,6 +386,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -395,6 +430,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -403,6 +444,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -439,6 +486,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
@@ -142,6 +142,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -151,6 +157,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -188,6 +199,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -212,6 +228,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -287,6 +308,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -337,6 +366,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -375,6 +410,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -383,6 +424,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -419,6 +466,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l412cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbux-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -163,6 +169,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -200,6 +211,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -224,6 +240,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -299,6 +320,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -357,6 +386,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -395,6 +430,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -403,6 +444,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -439,6 +486,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
@@ -142,6 +142,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -151,6 +157,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -188,6 +199,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -212,6 +228,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -287,6 +308,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -337,6 +366,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -375,6 +410,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -383,6 +424,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -419,6 +466,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in5_pa0: adc1_in5_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in6_pa1: adc1_in6_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +118,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -123,6 +133,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -150,6 +165,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -164,6 +184,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -197,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -211,6 +240,14 @@
 
 			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
+			};
+
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
@@ -247,6 +284,18 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -257,6 +306,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -283,6 +338,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in5_pa0: adc1_in5_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in6_pa1: adc1_in6_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +118,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -123,6 +133,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -150,6 +165,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -164,6 +184,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -197,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -211,6 +240,14 @@
 
 			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
+			};
+
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
@@ -247,6 +284,18 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -257,6 +306,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -283,6 +338,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in5_pa0: adc1_in5_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in6_pa1: adc1_in6_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +118,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -123,6 +133,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -150,6 +165,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -164,6 +184,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -197,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -211,6 +240,14 @@
 
 			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
+			};
+
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
@@ -247,6 +284,18 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -257,6 +306,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -283,6 +338,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l412kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in5_pa0: adc1_in5_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in6_pa1: adc1_in6_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +118,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -123,6 +133,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -150,6 +165,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -164,6 +184,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -197,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -211,6 +240,14 @@
 
 			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
+			};
+
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
@@ -247,6 +284,18 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -257,6 +306,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -283,6 +338,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
@@ -208,6 +208,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -223,6 +229,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -270,6 +281,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -294,6 +310,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -369,6 +390,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -427,6 +456,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -465,6 +500,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -473,6 +514,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -519,6 +566,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
@@ -208,6 +208,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -223,6 +229,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -270,6 +281,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -294,6 +310,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -369,6 +390,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -427,6 +456,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -465,6 +500,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -473,6 +514,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -519,6 +566,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l412rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbix-pinctrl.dtsi
@@ -208,6 +208,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -223,6 +229,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -270,6 +281,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -294,6 +310,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -369,6 +390,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -427,6 +456,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -465,6 +500,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -473,6 +514,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -519,6 +566,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
@@ -200,6 +200,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -215,6 +221,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -262,6 +273,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -286,6 +302,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -361,6 +382,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -419,6 +448,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -457,6 +492,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -465,6 +506,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -505,6 +552,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
@@ -208,6 +208,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -223,6 +229,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -270,6 +281,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -294,6 +310,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -369,6 +390,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -427,6 +456,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -465,6 +500,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -473,6 +514,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -519,6 +566,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
@@ -200,6 +200,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -215,6 +221,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -262,6 +273,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -286,6 +302,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -361,6 +382,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -419,6 +448,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -457,6 +492,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -465,6 +506,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -505,6 +552,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in5_pa0: adc1_in5_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in6_pa1: adc1_in6_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -120,6 +124,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -129,6 +139,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -156,6 +171,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -170,6 +190,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -203,6 +228,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -217,6 +246,14 @@
 
 			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
+			};
+
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
@@ -261,6 +298,18 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -271,6 +320,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -301,6 +356,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in5_pa0: adc1_in5_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in6_pa1: adc1_in6_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -120,6 +124,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -129,6 +139,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -156,6 +171,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -170,6 +190,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -203,6 +228,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -217,6 +246,14 @@
 
 			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
+			};
+
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
@@ -261,6 +298,18 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -271,6 +320,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -301,6 +356,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in5_pa0: adc1_in5_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in6_pa1: adc1_in6_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +118,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -123,6 +133,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -150,6 +165,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -164,6 +184,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -197,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -211,6 +240,14 @@
 
 			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
+			};
+
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
@@ -251,6 +288,18 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -261,6 +310,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -291,6 +346,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -163,6 +169,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -200,6 +211,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -224,6 +240,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -299,6 +320,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -357,6 +386,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -395,6 +430,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -403,6 +444,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -439,6 +486,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l422cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbux-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -163,6 +169,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -200,6 +211,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -224,6 +240,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -299,6 +320,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -357,6 +386,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -395,6 +430,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -403,6 +444,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -439,6 +486,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in5_pa0: adc1_in5_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in6_pa1: adc1_in6_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +118,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -123,6 +133,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -150,6 +165,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -164,6 +184,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -197,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -211,6 +240,14 @@
 
 			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
+			};
+
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
@@ -247,6 +284,18 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -257,6 +306,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -283,6 +338,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l422kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbux-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in5_pa0: adc1_in5_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in6_pa1: adc1_in6_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -114,6 +118,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -123,6 +133,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -150,6 +165,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -164,6 +184,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -197,6 +222,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -211,6 +240,14 @@
 
 			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
+			};
+
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
@@ -247,6 +284,18 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -257,6 +306,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -283,6 +338,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l422rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbix-pinctrl.dtsi
@@ -208,6 +208,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -223,6 +229,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -270,6 +281,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -294,6 +310,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -369,6 +390,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -427,6 +456,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -465,6 +500,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -473,6 +514,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -519,6 +566,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
@@ -208,6 +208,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -223,6 +229,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -270,6 +281,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -294,6 +310,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -369,6 +390,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -427,6 +456,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -465,6 +500,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -473,6 +514,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -519,6 +566,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
@@ -12,6 +12,10 @@
 
 			/* ADC_IN / ADC_INN / ADC_INP */
 
+			adc1_in5_pa0: adc1_in5_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			adc1_in6_pa1: adc1_in6_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -120,6 +124,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -129,6 +139,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -156,6 +171,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -170,6 +190,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -203,6 +228,10 @@
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -217,6 +246,14 @@
 
 			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
+			};
+
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
@@ -261,6 +298,18 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -271,6 +320,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -301,6 +356,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -166,8 +172,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -205,6 +221,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -225,6 +246,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -237,6 +263,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -244,6 +275,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -309,6 +345,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -367,6 +411,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -405,6 +455,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -413,6 +469,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -449,6 +511,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -166,8 +172,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -205,6 +221,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -225,6 +246,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -237,6 +263,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -244,6 +275,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -309,6 +345,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -367,6 +411,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -405,6 +455,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -413,6 +469,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -449,6 +511,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
@@ -158,6 +158,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -170,8 +176,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -214,6 +230,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -234,6 +255,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -246,6 +272,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -253,6 +284,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -318,6 +354,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -376,6 +420,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -414,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -422,6 +478,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -458,6 +520,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
@@ -109,6 +109,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -118,6 +124,16 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -150,6 +166,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -157,6 +178,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -169,6 +195,16 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -222,6 +258,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
@@ -256,6 +300,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
@@ -272,6 +322,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -298,6 +354,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
@@ -184,6 +184,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -202,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -209,6 +220,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -261,6 +277,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -281,6 +302,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -293,6 +319,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -300,6 +331,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -370,6 +406,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -428,6 +472,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -466,6 +516,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -474,6 +530,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -520,6 +582,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
@@ -184,6 +184,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -202,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -209,6 +220,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -261,6 +277,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -281,6 +302,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -293,6 +319,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -300,6 +331,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -370,6 +406,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -428,6 +472,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -466,6 +516,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -474,6 +530,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -520,6 +582,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
@@ -184,6 +184,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -202,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -209,6 +220,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -261,6 +277,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -281,6 +302,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -293,6 +319,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -300,6 +331,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -370,6 +406,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -428,6 +472,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -466,6 +516,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -474,6 +530,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -520,6 +582,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l431vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vcix-pinctrl.dtsi
@@ -193,6 +193,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -208,6 +214,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -228,6 +239,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -290,6 +306,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -320,6 +341,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -329,6 +355,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -349,6 +380,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -447,6 +483,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -509,6 +553,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -559,6 +609,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -573,6 +629,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -625,6 +687,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l431vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vctx-pinctrl.dtsi
@@ -193,6 +193,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -208,6 +214,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -228,6 +239,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -290,6 +306,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -320,6 +341,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -329,6 +355,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -349,6 +380,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -447,6 +483,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -509,6 +553,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -559,6 +609,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -573,6 +629,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -625,6 +687,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
@@ -109,6 +109,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -118,6 +124,16 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -150,6 +166,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -157,6 +178,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -169,6 +195,16 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -222,6 +258,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
@@ -256,6 +300,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
@@ -272,6 +322,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -298,6 +354,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -166,8 +172,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -205,6 +221,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -225,6 +246,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -237,6 +263,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -244,6 +275,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -309,6 +345,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -367,6 +411,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -405,6 +455,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -413,6 +469,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -449,6 +511,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -166,8 +172,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -205,6 +221,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -225,6 +246,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -237,6 +263,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -244,6 +275,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -309,6 +345,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -367,6 +411,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -405,6 +455,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -413,6 +469,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -449,6 +511,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -158,6 +158,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -170,8 +176,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -214,6 +230,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -234,6 +255,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -246,6 +272,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -253,6 +284,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -318,6 +354,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -376,6 +420,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -414,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -422,6 +478,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -458,6 +520,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -184,6 +184,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -202,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -209,6 +220,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -261,6 +277,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -281,6 +302,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -293,6 +319,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -300,6 +331,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -370,6 +406,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -428,6 +472,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -466,6 +516,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -474,6 +530,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -520,6 +582,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -184,6 +184,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -202,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -209,6 +220,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -261,6 +277,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -281,6 +302,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -293,6 +319,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -300,6 +331,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -370,6 +406,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -428,6 +472,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -466,6 +516,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -474,6 +530,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -520,6 +582,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -184,6 +184,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -202,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -209,6 +220,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -261,6 +277,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -281,6 +302,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -293,6 +319,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -300,6 +331,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -370,6 +406,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -428,6 +472,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -466,6 +516,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -474,6 +530,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -520,6 +582,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -180,6 +180,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -198,6 +204,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -205,6 +216,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -257,6 +273,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -277,6 +298,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -289,6 +315,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -296,6 +327,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -366,6 +402,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -424,6 +468,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -462,6 +512,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -470,6 +526,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -510,6 +572,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -193,6 +193,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -208,6 +214,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -228,6 +239,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -290,6 +306,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -320,6 +341,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -329,6 +355,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -349,6 +380,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -447,6 +483,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -509,6 +553,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -559,6 +609,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -573,6 +629,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -625,6 +687,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -193,6 +193,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -208,6 +214,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -228,6 +239,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -290,6 +306,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -320,6 +341,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -329,6 +355,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -349,6 +380,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -447,6 +483,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -509,6 +553,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -559,6 +609,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -573,6 +629,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -625,6 +687,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l442kcux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l442kcux-pinctrl.dtsi
@@ -109,6 +109,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -118,6 +124,16 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -150,6 +166,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -157,6 +178,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -169,6 +195,16 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -222,6 +258,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
@@ -256,6 +300,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
@@ -272,6 +322,12 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -298,6 +354,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -166,8 +172,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -205,6 +221,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -225,6 +246,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -237,6 +263,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -244,6 +275,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -309,6 +345,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -367,6 +411,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -405,6 +455,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -413,6 +469,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -449,6 +511,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -154,6 +154,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -166,8 +172,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -205,6 +221,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -225,6 +246,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -237,6 +263,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -244,6 +275,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -309,6 +345,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -367,6 +411,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -405,6 +455,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -413,6 +469,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -449,6 +511,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -158,6 +158,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {
@@ -170,8 +176,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -214,6 +230,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -234,6 +255,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -246,6 +272,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -253,6 +284,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -318,6 +354,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -376,6 +420,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -414,6 +464,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -422,6 +478,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -458,6 +520,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -184,6 +184,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -202,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -209,6 +220,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -261,6 +277,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -281,6 +302,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -293,6 +319,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -300,6 +331,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -370,6 +406,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -428,6 +472,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -466,6 +516,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -474,6 +530,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -520,6 +582,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -184,6 +184,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -202,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -209,6 +220,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -261,6 +277,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -281,6 +302,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -293,6 +319,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -300,6 +331,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -370,6 +406,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -428,6 +472,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -466,6 +516,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -474,6 +530,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -520,6 +582,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -184,6 +184,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -202,6 +208,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -209,6 +220,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -261,6 +277,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -281,6 +302,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -293,6 +319,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -300,6 +331,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -370,6 +406,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -428,6 +472,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -466,6 +516,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -474,6 +530,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -520,6 +582,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -193,6 +193,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -208,6 +214,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -228,6 +239,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -290,6 +306,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -320,6 +341,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -329,6 +355,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -349,6 +380,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -447,6 +483,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -509,6 +553,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -559,6 +609,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -573,6 +629,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -625,6 +687,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -193,6 +193,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -208,6 +214,11 @@
 
 			spi1_miso_pa11: spi1_miso_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
+				bias-pull-down;
+			};
+
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
 				bias-pull-down;
 			};
 
@@ -228,6 +239,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -290,6 +306,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -320,6 +341,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -329,6 +355,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -349,6 +380,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -447,6 +483,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -509,6 +553,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -559,6 +609,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -573,6 +629,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -625,6 +687,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
@@ -180,6 +180,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -204,8 +210,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -243,6 +259,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -263,6 +284,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -275,6 +301,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -282,6 +313,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -347,6 +383,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -369,6 +413,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -425,6 +473,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -469,6 +523,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -481,6 +541,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -489,6 +555,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -513,6 +585,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
@@ -216,6 +216,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -252,6 +258,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -259,6 +270,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -311,6 +327,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -331,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -343,6 +369,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -350,6 +381,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -420,6 +456,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -442,6 +486,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -514,6 +562,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -558,6 +612,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -566,6 +626,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -584,6 +650,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -612,6 +684,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
@@ -216,6 +216,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -252,6 +258,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -259,6 +270,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -311,6 +327,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -331,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -343,6 +369,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -350,6 +381,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -420,6 +456,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -442,6 +486,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -514,6 +562,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -558,6 +612,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -566,6 +626,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -584,6 +650,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -612,6 +684,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
@@ -216,6 +216,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -252,6 +258,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -259,6 +270,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -311,6 +327,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -331,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -343,6 +369,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -350,6 +381,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -420,6 +456,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -442,6 +486,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -514,6 +562,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -558,6 +612,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -566,6 +626,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -584,6 +650,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -612,6 +684,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
@@ -231,6 +231,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -273,6 +279,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -290,6 +301,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -352,6 +368,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -382,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -391,6 +417,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -411,6 +442,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -509,6 +545,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -531,6 +575,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -623,6 +671,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -679,6 +733,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -693,6 +753,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -721,6 +787,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -745,6 +817,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
@@ -231,6 +231,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -273,6 +279,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -290,6 +301,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -352,6 +368,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -382,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -391,6 +417,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -411,6 +442,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -509,6 +545,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -531,6 +575,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -623,6 +671,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -679,6 +733,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -693,6 +753,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -721,6 +787,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -745,6 +817,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
@@ -180,6 +180,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -204,8 +210,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -243,6 +259,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -263,6 +284,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -275,6 +301,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -282,6 +313,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -347,6 +383,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -369,6 +413,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -425,6 +473,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -469,6 +523,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -481,6 +541,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -489,6 +555,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -513,6 +585,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -216,6 +216,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -252,6 +258,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -259,6 +270,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -311,6 +327,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -331,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -343,6 +369,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -350,6 +381,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -420,6 +456,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -442,6 +486,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -514,6 +562,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -558,6 +612,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -566,6 +626,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -584,6 +650,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -612,6 +684,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -216,6 +216,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -252,6 +258,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -259,6 +270,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -311,6 +327,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -331,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -343,6 +369,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -350,6 +381,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -420,6 +456,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -442,6 +486,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -514,6 +562,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -558,6 +612,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -566,6 +626,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -584,6 +650,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -612,6 +684,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -216,6 +216,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -252,6 +258,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -259,6 +270,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -311,6 +327,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -331,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -343,6 +369,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -350,6 +381,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -420,6 +456,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -442,6 +486,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -514,6 +562,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -558,6 +612,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -566,6 +626,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -584,6 +650,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -612,6 +684,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -212,6 +212,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -248,6 +254,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -255,6 +266,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -307,6 +323,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -327,6 +348,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -339,6 +365,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -346,6 +377,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -416,6 +452,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -438,6 +482,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -510,6 +558,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -554,6 +608,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -566,6 +626,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -574,6 +640,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -602,6 +674,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -231,6 +231,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -273,6 +279,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -290,6 +301,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -352,6 +368,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -382,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -391,6 +417,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -411,6 +442,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -509,6 +545,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -531,6 +575,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -623,6 +671,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -679,6 +733,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -693,6 +753,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -721,6 +787,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -745,6 +817,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -231,6 +231,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -273,6 +279,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -290,6 +301,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -352,6 +368,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -382,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -391,6 +417,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -411,6 +442,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -509,6 +545,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -531,6 +575,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -623,6 +671,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -679,6 +733,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -693,6 +753,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -721,6 +787,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -745,6 +817,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l462ceux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462ceux-pinctrl.dtsi
@@ -180,6 +180,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -204,8 +210,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -243,6 +259,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -263,6 +284,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -275,6 +301,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -282,6 +313,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -347,6 +383,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -369,6 +413,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -425,6 +473,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -469,6 +523,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -481,6 +541,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -489,6 +555,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -513,6 +585,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -216,6 +216,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -252,6 +258,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -259,6 +270,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -311,6 +327,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -331,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -343,6 +369,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -350,6 +381,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -420,6 +456,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -442,6 +486,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -514,6 +562,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -558,6 +612,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -566,6 +626,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -584,6 +650,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -612,6 +684,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -216,6 +216,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -252,6 +258,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -259,6 +270,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -311,6 +327,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -331,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -343,6 +369,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -350,6 +381,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -420,6 +456,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -442,6 +486,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -514,6 +562,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -558,6 +612,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -566,6 +626,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -584,6 +650,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -612,6 +684,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -216,6 +216,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -252,6 +258,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -259,6 +270,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -311,6 +327,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -331,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -343,6 +369,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -350,6 +381,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -420,6 +456,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -442,6 +486,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -514,6 +562,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -558,6 +612,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -566,6 +626,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -584,6 +650,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -612,6 +684,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -231,6 +231,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -273,6 +279,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -290,6 +301,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -352,6 +368,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -382,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -391,6 +417,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -411,6 +442,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -509,6 +545,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -531,6 +575,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -623,6 +671,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -679,6 +733,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -693,6 +753,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -721,6 +787,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -745,6 +817,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -231,6 +231,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -273,6 +279,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -290,6 +301,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -352,6 +368,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -382,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -391,6 +417,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -411,6 +442,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -509,6 +545,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -531,6 +575,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -623,6 +671,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -679,6 +733,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -693,6 +753,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -721,6 +787,12 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -745,6 +817,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -316,6 +316,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -338,6 +343,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -410,6 +420,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -440,6 +455,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -449,6 +469,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -474,6 +499,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -577,6 +607,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -599,6 +637,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -801,6 +843,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -869,6 +917,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -919,6 +973,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
@@ -259,6 +259,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -266,6 +271,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -313,6 +323,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pb9: spi2_nss_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF5)>;
 				bias-pull-up;
@@ -328,10 +343,20 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -342,6 +367,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -412,6 +442,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -434,6 +472,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -584,6 +626,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -628,6 +676,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -654,6 +708,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -268,6 +268,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -285,6 +290,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -342,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -367,10 +382,20 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -391,6 +416,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -489,6 +519,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -511,6 +549,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -701,6 +743,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -757,6 +805,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -795,6 +849,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -336,6 +336,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -358,6 +363,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -430,6 +440,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -460,6 +475,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -469,6 +489,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -494,6 +519,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -597,6 +627,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -619,6 +657,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -845,6 +887,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -913,6 +961,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -963,6 +1017,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -336,6 +336,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -358,6 +363,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -430,6 +440,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -460,6 +475,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -469,6 +489,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -494,6 +519,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -597,6 +627,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -619,6 +657,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -845,6 +887,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -913,6 +961,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -963,6 +1017,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -259,6 +259,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -266,6 +271,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -313,6 +323,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pb9: spi2_nss_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF5)>;
 				bias-pull-up;
@@ -328,10 +343,20 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -342,6 +367,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -412,6 +442,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -434,6 +472,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -584,6 +626,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -628,6 +676,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -654,6 +708,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -268,6 +268,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -285,6 +290,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -342,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -367,10 +382,20 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -391,6 +416,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -489,6 +519,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -511,6 +549,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -701,6 +743,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -757,6 +805,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -795,6 +849,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -271,6 +271,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -278,6 +283,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -335,6 +345,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pb9: spi2_nss_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF5)>;
 				bias-pull-up;
@@ -350,6 +365,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -362,6 +382,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -369,6 +394,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -444,6 +474,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -466,6 +504,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -628,6 +670,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -678,6 +726,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -710,6 +764,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -263,6 +263,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -270,6 +275,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -322,6 +332,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pb9: spi2_nss_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF5)>;
 				bias-pull-up;
@@ -337,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -349,6 +369,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -356,6 +381,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -431,6 +461,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -453,6 +491,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -611,6 +653,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -655,6 +703,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -687,6 +741,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -271,6 +271,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -278,6 +283,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -340,6 +350,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pb9: spi2_nss_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF5)>;
 				bias-pull-up;
@@ -355,6 +370,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -367,6 +387,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -374,6 +399,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -453,6 +483,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -475,6 +513,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -637,6 +679,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -687,6 +735,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -725,6 +779,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -316,6 +316,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -338,6 +343,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -410,6 +420,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -440,6 +455,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -449,6 +469,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -474,6 +499,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -577,6 +607,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -599,6 +637,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -801,6 +843,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -869,6 +917,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -919,6 +973,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -259,6 +259,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -266,6 +271,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -313,6 +323,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pb9: spi2_nss_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF5)>;
 				bias-pull-up;
@@ -328,10 +343,20 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -342,6 +367,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -412,6 +442,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -434,6 +472,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -584,6 +626,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -628,6 +676,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -654,6 +708,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -268,6 +268,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -285,6 +290,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -342,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -367,10 +382,20 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -391,6 +416,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -489,6 +519,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -511,6 +549,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -701,6 +743,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -757,6 +805,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -795,6 +849,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -336,6 +336,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -358,6 +363,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -430,6 +440,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -460,6 +475,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -469,6 +489,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -494,6 +519,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -597,6 +627,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -619,6 +657,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -845,6 +887,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -913,6 +961,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -963,6 +1017,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -336,6 +336,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -358,6 +363,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -430,6 +440,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -460,6 +475,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -469,6 +489,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -494,6 +519,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -597,6 +627,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -619,6 +657,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -845,6 +887,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -913,6 +961,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -963,6 +1017,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -330,6 +330,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -352,6 +357,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -424,6 +434,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -454,6 +469,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -463,6 +483,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -488,6 +513,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -591,6 +621,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -609,6 +647,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -835,6 +877,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -903,6 +951,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -953,6 +1007,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -271,6 +271,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -278,6 +283,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -335,6 +345,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pb9: spi2_nss_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF5)>;
 				bias-pull-up;
@@ -350,6 +365,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -362,6 +382,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -369,6 +394,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -444,6 +474,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -466,6 +504,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -628,6 +670,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -678,6 +726,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -710,6 +764,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -271,6 +271,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -278,6 +283,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -335,6 +345,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pb9: spi2_nss_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF5)>;
 				bias-pull-up;
@@ -350,6 +365,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -362,6 +382,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
 				slew-rate = "very-high-speed";
@@ -369,6 +394,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -444,6 +474,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -466,6 +504,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -628,6 +670,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -678,6 +726,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -710,6 +764,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -316,6 +316,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -338,6 +343,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -410,6 +420,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -440,6 +455,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -449,6 +469,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -474,6 +499,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -577,6 +607,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -599,6 +637,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -801,6 +843,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -869,6 +917,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -919,6 +973,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -259,6 +259,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -266,6 +271,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -313,6 +323,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi2_nss_pb9: spi2_nss_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF5)>;
 				bias-pull-up;
@@ -328,10 +343,20 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -342,6 +367,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -412,6 +442,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -434,6 +472,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -584,6 +626,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -628,6 +676,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -654,6 +708,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -268,6 +268,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -285,6 +290,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -342,6 +352,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -367,10 +382,20 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -391,6 +416,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -489,6 +519,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -511,6 +549,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -701,6 +743,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -757,6 +805,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -795,6 +849,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -336,6 +336,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -358,6 +363,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -430,6 +440,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pe12: spi1_nss_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
 				bias-pull-up;
@@ -460,6 +475,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -469,6 +489,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -494,6 +519,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -597,6 +627,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -619,6 +657,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -845,6 +887,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -913,6 +961,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -963,6 +1017,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -382,6 +382,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -448,6 +454,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -475,6 +486,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -562,6 +578,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -602,6 +623,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -616,6 +642,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -656,6 +687,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -759,6 +795,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -781,6 +825,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1037,6 +1085,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1111,6 +1165,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1141,6 +1201,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1161,6 +1227,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1197,6 +1275,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -382,6 +382,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -448,6 +454,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -475,6 +486,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -562,6 +578,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -602,6 +623,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -616,6 +642,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -656,6 +687,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -759,6 +795,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -781,6 +825,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1033,6 +1081,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1107,6 +1161,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1137,6 +1197,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1157,6 +1223,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1193,6 +1271,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -351,6 +351,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -411,6 +417,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -433,6 +444,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -515,6 +531,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -550,6 +571,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -564,6 +590,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -599,6 +630,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -702,6 +738,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -724,6 +768,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -932,6 +980,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1006,6 +1060,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1036,6 +1096,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1056,6 +1122,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1092,6 +1170,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -339,6 +339,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -393,6 +399,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -415,6 +426,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -497,6 +513,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -532,6 +553,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -546,6 +572,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -581,6 +612,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -684,6 +720,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -702,6 +746,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -910,6 +958,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -984,6 +1038,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1014,6 +1074,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1034,6 +1100,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1070,6 +1148,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -288,6 +288,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -330,6 +336,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -337,6 +348,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -394,6 +410,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -414,6 +435,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -423,6 +449,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -438,6 +469,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -508,6 +544,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -530,6 +574,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -686,6 +734,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -736,6 +790,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -744,6 +804,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -762,6 +828,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -790,6 +868,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -280,6 +280,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -322,6 +328,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -329,6 +340,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -386,6 +402,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -406,6 +427,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -415,6 +441,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -430,6 +461,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -500,6 +536,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -522,6 +566,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -678,6 +726,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -728,6 +782,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -740,6 +800,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -748,6 +814,18 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -776,6 +854,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -303,6 +303,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -351,6 +357,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -368,6 +379,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -435,6 +451,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -465,6 +486,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -474,6 +500,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -504,6 +535,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -602,6 +638,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -624,6 +668,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -820,6 +868,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -882,6 +936,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -896,6 +956,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -924,6 +990,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -948,6 +1026,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -297,6 +297,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -339,6 +345,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -351,6 +362,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -428,6 +444,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -458,6 +479,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -472,6 +498,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -497,6 +528,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -600,6 +636,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -622,6 +666,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -814,6 +862,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -870,6 +924,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -894,6 +954,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -908,6 +974,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -940,6 +1018,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -289,6 +289,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -331,6 +337,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -343,6 +354,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -420,6 +436,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -450,6 +471,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -464,6 +490,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -489,6 +520,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -592,6 +628,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -614,6 +658,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -806,6 +854,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -862,6 +916,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -886,6 +946,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -900,6 +966,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -932,6 +1010,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -371,6 +371,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -431,6 +437,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -453,6 +464,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -535,6 +551,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -570,6 +591,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -584,6 +610,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -619,6 +650,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -722,6 +758,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -744,6 +788,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -976,6 +1024,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1050,6 +1104,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1080,6 +1140,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1100,6 +1166,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1136,6 +1214,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -365,6 +365,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -419,6 +425,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -441,6 +452,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -523,6 +539,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -558,6 +579,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -572,6 +598,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -607,6 +638,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -710,6 +746,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -728,6 +772,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -960,6 +1008,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1034,6 +1088,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1064,6 +1124,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1084,6 +1150,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1120,6 +1198,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -382,6 +382,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -448,6 +454,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -475,6 +486,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -562,6 +578,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -602,6 +623,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -616,6 +642,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -656,6 +687,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -759,6 +795,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -781,6 +825,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1037,6 +1085,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1111,6 +1165,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1141,6 +1201,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1161,6 +1227,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1197,6 +1275,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -382,6 +382,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -448,6 +454,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -475,6 +486,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -562,6 +578,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -602,6 +623,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -616,6 +642,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -656,6 +687,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -759,6 +795,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -781,6 +825,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -1033,6 +1081,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1107,6 +1161,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1137,6 +1197,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1157,6 +1223,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1193,6 +1271,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -351,6 +351,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -411,6 +417,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -433,6 +444,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -515,6 +531,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -550,6 +571,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -564,6 +590,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -599,6 +630,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -702,6 +738,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -724,6 +768,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -932,6 +980,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1006,6 +1060,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1036,6 +1096,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1056,6 +1122,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1092,6 +1170,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -339,6 +339,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -393,6 +399,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -415,6 +426,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -497,6 +513,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -532,6 +553,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -546,6 +572,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -581,6 +612,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -684,6 +720,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -702,6 +746,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -910,6 +958,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -984,6 +1038,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1014,6 +1074,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1034,6 +1100,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1070,6 +1148,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -288,6 +288,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -330,6 +336,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -337,6 +348,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -394,6 +410,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -414,6 +435,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -423,6 +449,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -438,6 +469,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -508,6 +544,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -530,6 +574,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -686,6 +734,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -736,6 +790,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -744,6 +804,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -762,6 +828,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -790,6 +868,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -280,6 +280,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -322,6 +328,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -329,6 +340,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -386,6 +402,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -406,6 +427,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -415,6 +441,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -430,6 +461,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -500,6 +536,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -522,6 +566,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -678,6 +726,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -728,6 +782,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -740,6 +800,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -748,6 +814,18 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -776,6 +854,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -303,6 +303,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -351,6 +357,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -368,6 +379,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -435,6 +451,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -465,6 +486,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -474,6 +500,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -504,6 +535,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -602,6 +638,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -624,6 +668,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -820,6 +868,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -882,6 +936,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -896,6 +956,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -924,6 +990,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -948,6 +1026,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -297,6 +297,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -339,6 +345,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -351,6 +362,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -428,6 +444,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -458,6 +479,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -472,6 +498,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -497,6 +528,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -600,6 +636,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -622,6 +666,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -814,6 +862,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -870,6 +924,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -894,6 +954,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -908,6 +974,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -940,6 +1018,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -289,6 +289,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -331,6 +337,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -343,6 +354,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -420,6 +436,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -450,6 +471,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -464,6 +490,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -489,6 +520,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -592,6 +628,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -614,6 +658,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -806,6 +854,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -862,6 +916,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -886,6 +946,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -900,6 +966,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -932,6 +1010,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -371,6 +371,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -431,6 +437,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -453,6 +464,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -535,6 +551,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -570,6 +591,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -584,6 +610,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -619,6 +650,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -722,6 +758,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -744,6 +788,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -976,6 +1024,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1050,6 +1104,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1080,6 +1140,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1100,6 +1166,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1136,6 +1214,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -365,6 +365,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -419,6 +425,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -441,6 +452,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -523,6 +539,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -558,6 +579,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -572,6 +598,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -607,6 +638,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -710,6 +746,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -728,6 +772,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -960,6 +1008,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1034,6 +1088,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1064,6 +1124,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1084,6 +1150,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1120,6 +1198,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -326,6 +326,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -386,6 +392,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -413,6 +424,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -505,6 +521,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -545,6 +566,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -559,6 +585,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -599,6 +630,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -702,6 +738,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -724,6 +768,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -980,6 +1028,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1054,6 +1108,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1084,6 +1144,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1104,6 +1170,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1140,6 +1218,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -326,6 +326,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -386,6 +392,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -413,6 +424,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -505,6 +521,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -545,6 +566,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -559,6 +585,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -599,6 +630,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -702,6 +738,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -724,6 +768,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -976,6 +1024,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -1050,6 +1104,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1080,6 +1140,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1100,6 +1166,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1136,6 +1214,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -194,6 +194,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -218,8 +224,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -257,6 +273,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -277,6 +298,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -286,6 +312,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -301,6 +332,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -366,6 +402,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -388,6 +432,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -512,6 +560,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -556,6 +610,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -568,6 +628,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -576,6 +642,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -600,6 +672,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -194,6 +194,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -218,8 +224,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -257,6 +273,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -277,6 +298,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -286,6 +312,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -301,6 +332,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -366,6 +402,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -388,6 +432,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -512,6 +560,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -556,6 +610,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -568,6 +628,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -576,6 +642,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -600,6 +672,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -177,6 +177,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -195,8 +201,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -234,6 +250,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -254,6 +275,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -263,6 +289,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -278,6 +309,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -343,6 +379,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -361,6 +405,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -477,6 +525,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -521,6 +575,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -533,6 +593,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -541,6 +607,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -565,6 +637,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -177,6 +177,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -195,8 +201,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -234,6 +250,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -254,6 +275,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -263,6 +289,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -278,6 +309,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -343,6 +379,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -361,6 +405,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -477,6 +525,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -521,6 +575,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -533,6 +593,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -541,6 +607,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -565,6 +637,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -299,6 +299,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -353,6 +359,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -375,6 +386,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -462,6 +478,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -497,6 +518,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -511,6 +537,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -546,6 +577,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +685,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -671,6 +715,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -879,6 +927,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -953,6 +1007,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -983,6 +1043,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1003,6 +1069,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1039,6 +1117,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -287,6 +287,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -335,6 +341,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -357,6 +368,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -444,6 +460,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -479,6 +500,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -493,6 +519,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -528,6 +559,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -631,6 +667,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -649,6 +693,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -857,6 +905,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -931,6 +985,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -961,6 +1021,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -981,6 +1047,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1017,6 +1095,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -248,6 +248,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -284,6 +290,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -291,6 +302,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -348,6 +364,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -368,6 +389,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -377,6 +403,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -392,6 +423,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -462,6 +498,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -484,6 +528,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -640,6 +688,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -684,6 +738,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -692,6 +752,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -710,6 +776,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -738,6 +810,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -240,6 +240,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -276,6 +282,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -283,6 +294,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -340,6 +356,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -360,6 +381,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -369,6 +395,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -384,6 +415,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -454,6 +490,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -476,6 +520,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -632,6 +680,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -676,6 +730,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -688,6 +748,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -696,6 +762,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -724,6 +796,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -263,6 +263,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -305,6 +311,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -322,6 +333,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -394,6 +410,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -424,6 +445,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -433,6 +459,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -463,6 +494,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -561,6 +597,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -583,6 +627,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -779,6 +827,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -841,6 +895,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -855,6 +915,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -883,6 +949,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -907,6 +985,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -257,6 +257,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -293,6 +299,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -305,6 +316,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -387,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -417,6 +438,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -431,6 +457,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -456,6 +487,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -559,6 +595,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -581,6 +625,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -773,6 +821,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -829,6 +883,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -853,6 +913,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -867,6 +933,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -899,6 +977,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -257,6 +257,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -293,6 +299,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -310,6 +321,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -382,6 +398,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -412,6 +433,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -421,6 +447,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -451,6 +482,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -549,6 +585,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -567,6 +611,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -759,6 +807,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -821,6 +875,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -835,6 +895,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -863,6 +929,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -887,6 +965,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -249,6 +249,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -285,6 +291,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -297,6 +308,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -379,6 +395,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -409,6 +430,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -423,6 +449,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -448,6 +479,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -551,6 +587,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -573,6 +617,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -765,6 +813,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -821,6 +875,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -845,6 +905,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -859,6 +925,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -891,6 +969,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -299,6 +299,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -353,6 +359,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -375,6 +386,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -462,6 +478,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -497,6 +518,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -511,6 +537,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -546,6 +577,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +685,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -671,6 +715,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -903,6 +951,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -977,6 +1031,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1007,6 +1067,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1027,6 +1093,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1063,6 +1141,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -293,6 +293,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -341,6 +347,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -363,6 +374,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -450,6 +466,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -485,6 +506,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -499,6 +525,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -534,6 +565,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -637,6 +673,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -655,6 +699,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -887,6 +935,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -961,6 +1015,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -991,6 +1051,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1011,6 +1077,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1047,6 +1125,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -262,6 +262,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -322,6 +328,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -349,6 +360,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -441,6 +457,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -481,6 +502,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -495,6 +521,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -535,6 +566,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -638,6 +674,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -660,6 +704,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -916,6 +964,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -990,6 +1044,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1020,6 +1080,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1040,6 +1106,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1076,6 +1154,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -194,6 +194,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -218,8 +224,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -257,6 +273,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -277,6 +298,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -286,6 +312,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -301,6 +332,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -366,6 +402,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -388,6 +432,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -512,6 +560,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -556,6 +610,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -568,6 +628,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -576,6 +642,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -600,6 +672,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -194,6 +194,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -218,8 +224,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -257,6 +273,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -277,6 +298,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -286,6 +312,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -301,6 +332,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -366,6 +402,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -388,6 +432,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -512,6 +560,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -556,6 +610,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -568,6 +628,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -576,6 +642,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -600,6 +672,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -299,6 +299,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -353,6 +359,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -375,6 +386,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -462,6 +478,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -497,6 +518,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -511,6 +537,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -546,6 +577,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +685,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -671,6 +715,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -879,6 +927,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -953,6 +1007,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -983,6 +1043,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1003,6 +1069,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1039,6 +1117,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -248,6 +248,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -284,6 +290,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -291,6 +302,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -348,6 +364,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -368,6 +389,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -377,6 +403,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -392,6 +423,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -462,6 +498,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -484,6 +528,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -640,6 +688,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -684,6 +738,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -692,6 +752,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -710,6 +776,12 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -738,6 +810,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -263,6 +263,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -305,6 +311,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -322,6 +333,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -394,6 +410,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -424,6 +445,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -433,6 +459,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -463,6 +494,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -561,6 +597,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -583,6 +627,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -779,6 +827,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -841,6 +895,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -855,6 +915,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -883,6 +949,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -907,6 +985,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -257,6 +257,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -293,6 +299,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -305,6 +316,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -387,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -417,6 +438,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -431,6 +457,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -456,6 +487,11 @@
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -559,6 +595,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -581,6 +625,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -773,6 +821,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -829,6 +883,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -853,6 +913,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -867,6 +933,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -899,6 +977,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -299,6 +299,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -353,6 +359,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -375,6 +386,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -462,6 +478,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -497,6 +518,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -511,6 +537,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -546,6 +577,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -649,6 +685,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -671,6 +715,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -903,6 +951,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -977,6 +1031,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1007,6 +1067,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1027,6 +1093,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1063,6 +1141,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -262,6 +262,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -322,6 +328,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -349,6 +360,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -441,6 +457,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -481,6 +502,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -495,6 +521,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -535,6 +566,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -638,6 +674,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -660,6 +704,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -916,6 +964,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -990,6 +1044,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1020,6 +1080,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1040,6 +1106,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1076,6 +1154,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -235,6 +235,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -289,6 +295,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -311,6 +322,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -398,6 +414,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -433,6 +454,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -447,6 +473,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -482,6 +513,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -585,6 +621,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -607,6 +651,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -815,6 +863,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -889,6 +943,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -919,6 +979,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -939,6 +1005,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -975,6 +1053,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -199,6 +199,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -241,6 +247,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -258,6 +269,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -330,6 +346,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -360,6 +381,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -369,6 +395,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -399,6 +430,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -497,6 +533,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -519,6 +563,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -715,6 +763,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -777,6 +831,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -791,6 +851,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -819,6 +885,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -843,6 +921,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -235,6 +235,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -289,6 +295,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -311,6 +322,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -398,6 +414,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -433,6 +454,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -447,6 +473,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -482,6 +513,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -585,6 +621,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -607,6 +651,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -839,6 +887,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -913,6 +967,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -943,6 +1003,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -963,6 +1029,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -999,6 +1077,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -229,6 +229,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -283,6 +289,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -305,6 +316,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -387,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -422,6 +443,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -436,6 +462,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -471,6 +502,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -574,6 +610,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -596,6 +640,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -812,6 +860,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -880,6 +934,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -910,6 +970,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -930,6 +996,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -966,6 +1044,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -229,6 +229,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -277,6 +283,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -299,6 +310,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -386,6 +402,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -421,6 +442,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -435,6 +461,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -470,6 +501,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -573,6 +609,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -591,6 +635,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -823,6 +871,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -897,6 +951,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -927,6 +987,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -947,6 +1013,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -983,6 +1061,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -262,6 +262,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -322,6 +328,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -349,6 +360,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -441,6 +457,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -481,6 +502,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -495,6 +521,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -535,6 +566,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -638,6 +674,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -660,6 +704,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -916,6 +964,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -990,6 +1044,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1020,6 +1080,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1040,6 +1106,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1076,6 +1154,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -199,6 +199,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -241,6 +247,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -258,6 +269,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -330,6 +346,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -360,6 +381,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -369,6 +395,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -399,6 +430,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -497,6 +533,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -519,6 +563,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -715,6 +763,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -777,6 +831,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -791,6 +851,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -819,6 +885,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -843,6 +921,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -235,6 +235,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -289,6 +295,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -311,6 +322,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -398,6 +414,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -433,6 +454,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -447,6 +473,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -482,6 +513,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -585,6 +621,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -607,6 +651,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -839,6 +887,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -913,6 +967,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -943,6 +1003,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -963,6 +1029,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -999,6 +1077,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -246,6 +246,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -306,6 +312,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -333,6 +344,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -425,6 +441,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -465,6 +486,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -479,6 +505,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -519,6 +550,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -622,6 +658,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -644,6 +688,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -900,6 +948,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -974,6 +1028,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1004,6 +1064,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1024,6 +1090,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1060,6 +1138,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -189,6 +189,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -225,6 +231,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -242,6 +253,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -314,6 +330,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -344,6 +365,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -353,6 +379,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -383,6 +414,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -481,6 +517,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -503,6 +547,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -683,6 +731,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -739,6 +793,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -757,6 +817,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -771,6 +837,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -799,6 +877,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -229,6 +229,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -283,6 +289,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -305,6 +316,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -387,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -422,6 +443,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -436,6 +462,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -471,6 +502,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -574,6 +610,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -596,6 +640,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -824,6 +872,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -892,6 +946,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -922,6 +982,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -942,6 +1008,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -978,6 +1056,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -219,6 +219,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -273,6 +279,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -295,6 +306,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -382,6 +398,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -417,6 +438,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -431,6 +457,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -466,6 +497,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -569,6 +605,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -591,6 +635,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -811,6 +859,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -885,6 +939,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -915,6 +975,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -935,6 +1001,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -971,6 +1049,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -229,6 +229,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -283,6 +289,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -305,6 +316,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -387,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -422,6 +443,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -436,6 +462,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -471,6 +502,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -574,6 +610,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -596,6 +640,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -812,6 +860,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -880,6 +934,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -910,6 +970,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -930,6 +996,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -966,6 +1044,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -217,6 +217,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -265,6 +271,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -287,6 +298,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -369,6 +385,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -404,6 +425,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -418,6 +444,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -453,6 +484,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -556,6 +592,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -574,6 +618,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -790,6 +838,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -858,6 +912,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -888,6 +948,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -908,6 +974,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -944,6 +1022,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -262,6 +262,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -322,6 +328,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -349,6 +360,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -441,6 +457,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -481,6 +502,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -495,6 +521,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -535,6 +566,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -638,6 +674,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -660,6 +704,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -916,6 +964,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -990,6 +1044,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1020,6 +1080,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1040,6 +1106,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1076,6 +1154,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -235,6 +235,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -289,6 +295,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -311,6 +322,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -398,6 +414,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -433,6 +454,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -447,6 +473,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -482,6 +513,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -585,6 +621,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -607,6 +651,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -815,6 +863,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -889,6 +943,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -919,6 +979,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -939,6 +1005,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -975,6 +1053,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -199,6 +199,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -241,6 +247,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -258,6 +269,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -330,6 +346,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -360,6 +381,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -369,6 +395,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -399,6 +430,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -497,6 +533,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -519,6 +563,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -715,6 +763,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -777,6 +831,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -791,6 +851,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -819,6 +885,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -843,6 +921,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -235,6 +235,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -289,6 +295,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -311,6 +322,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -398,6 +414,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -433,6 +454,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -447,6 +473,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -482,6 +513,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -585,6 +621,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -607,6 +651,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -839,6 +887,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -913,6 +967,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -943,6 +1003,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -963,6 +1029,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -999,6 +1077,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -229,6 +229,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -283,6 +289,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -305,6 +316,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -387,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -422,6 +443,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -436,6 +462,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -471,6 +502,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -574,6 +610,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -596,6 +640,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -812,6 +860,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -880,6 +934,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -910,6 +970,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -930,6 +996,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -966,6 +1044,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -262,6 +262,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -322,6 +328,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -349,6 +360,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -441,6 +457,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -481,6 +502,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -495,6 +521,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -535,6 +566,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -638,6 +674,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -660,6 +704,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -916,6 +964,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -990,6 +1044,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1020,6 +1080,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1040,6 +1106,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1076,6 +1154,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -199,6 +199,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -241,6 +247,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -258,6 +269,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -330,6 +346,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -360,6 +381,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -369,6 +395,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -399,6 +430,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -497,6 +533,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -519,6 +563,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -715,6 +763,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -777,6 +831,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -791,6 +851,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -819,6 +885,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -843,6 +921,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -235,6 +235,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -289,6 +295,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -311,6 +322,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -398,6 +414,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -433,6 +454,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -447,6 +473,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -482,6 +513,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -585,6 +621,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -607,6 +651,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -839,6 +887,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -913,6 +967,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -943,6 +1003,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -963,6 +1029,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -999,6 +1077,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -246,6 +246,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -306,6 +312,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -333,6 +344,11 @@
 
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -425,6 +441,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -465,6 +486,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -479,6 +505,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -519,6 +550,11 @@
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -622,6 +658,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -644,6 +688,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -900,6 +948,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -974,6 +1028,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -1004,6 +1064,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1024,6 +1090,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1060,6 +1138,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -189,6 +189,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -225,6 +231,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -242,6 +253,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -314,6 +330,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -344,6 +365,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -353,6 +379,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -383,6 +414,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -481,6 +517,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -503,6 +547,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -683,6 +731,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -739,6 +793,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -757,6 +817,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -771,6 +837,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -799,6 +877,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -229,6 +229,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -283,6 +289,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -305,6 +316,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -387,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -422,6 +443,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -436,6 +462,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -471,6 +502,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -574,6 +610,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -596,6 +640,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -824,6 +872,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -892,6 +946,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -922,6 +982,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -942,6 +1008,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -978,6 +1056,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -219,6 +219,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -273,6 +279,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -295,6 +306,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -382,6 +398,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -417,6 +438,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -431,6 +457,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -466,6 +497,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -569,6 +605,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -591,6 +635,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -811,6 +859,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -885,6 +939,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -915,6 +975,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -935,6 +1001,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -971,6 +1049,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -229,6 +229,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -283,6 +289,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -305,6 +316,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -387,6 +403,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -422,6 +443,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -436,6 +462,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -471,6 +502,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -574,6 +610,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -596,6 +640,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -812,6 +860,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -880,6 +934,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -910,6 +970,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -930,6 +996,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -966,6 +1044,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -192,6 +192,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -216,8 +222,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -255,6 +271,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -275,6 +296,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -284,6 +310,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -299,6 +330,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -364,6 +400,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -386,6 +430,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -510,6 +558,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -548,6 +602,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -560,6 +620,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -568,6 +634,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -592,6 +664,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -192,6 +192,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -216,8 +222,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -255,6 +271,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -275,6 +296,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -284,6 +310,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -299,6 +330,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -364,6 +400,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -386,6 +430,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -510,6 +558,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -548,6 +602,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -560,6 +620,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -568,6 +634,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -592,6 +664,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -176,6 +176,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -194,8 +200,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -233,6 +249,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -248,6 +269,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -257,6 +283,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -272,6 +303,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -337,6 +373,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -355,6 +399,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -471,6 +519,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -509,6 +563,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -521,6 +581,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -529,6 +595,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -553,6 +625,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -176,6 +176,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -194,8 +200,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -233,6 +249,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -248,6 +269,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -257,6 +283,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -272,6 +303,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -337,6 +373,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -355,6 +399,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -471,6 +519,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -509,6 +563,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -521,6 +581,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -529,6 +595,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -553,6 +625,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -250,6 +250,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -280,6 +286,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -292,6 +303,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -364,6 +380,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -384,6 +405,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -398,6 +424,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -418,6 +449,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -501,6 +537,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -523,6 +567,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -691,6 +739,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -735,6 +789,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -753,6 +813,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -767,6 +833,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -799,6 +877,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -250,6 +250,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -280,6 +286,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -287,6 +298,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -354,6 +370,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -374,6 +395,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -391,6 +417,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
 				slew-rate = "very-high-speed";
@@ -403,6 +434,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -478,6 +514,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -500,6 +544,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -668,6 +716,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -712,6 +766,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -730,6 +790,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -744,6 +810,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -776,6 +854,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -284,6 +284,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -332,6 +338,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -354,6 +365,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -436,6 +452,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -471,6 +492,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -485,6 +511,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -520,6 +551,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -623,6 +659,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -645,6 +689,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -849,6 +897,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -905,6 +959,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -935,6 +995,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -955,6 +1021,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -991,6 +1069,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -296,6 +296,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -344,6 +350,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -366,6 +377,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -453,6 +469,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -488,6 +509,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -502,6 +528,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -537,6 +568,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -640,6 +676,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -662,6 +706,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -870,6 +918,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -932,6 +986,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -962,6 +1022,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -982,6 +1048,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1018,6 +1096,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -296,6 +296,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -344,6 +350,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -366,6 +377,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -448,6 +464,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -483,6 +504,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -497,6 +523,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -532,6 +563,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -635,6 +671,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -657,6 +701,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -861,6 +909,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -917,6 +971,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -947,6 +1007,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -967,6 +1033,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1003,6 +1081,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -246,6 +246,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -276,6 +282,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -283,6 +294,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -340,6 +356,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -360,6 +381,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -369,6 +395,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -384,6 +415,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -454,6 +490,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -476,6 +520,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -632,6 +680,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -670,6 +724,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -678,6 +738,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -696,6 +762,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -724,6 +802,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -238,6 +238,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -268,6 +274,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -275,6 +286,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -332,6 +348,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -352,6 +373,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -361,6 +387,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -376,6 +407,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -446,6 +482,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -468,6 +512,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -624,6 +672,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -662,6 +716,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -674,6 +734,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -682,6 +748,18 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -710,6 +788,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -214,6 +214,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -238,6 +244,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -245,6 +256,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -302,6 +318,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -309,6 +330,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -324,6 +350,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
 				slew-rate = "very-high-speed";
@@ -336,6 +367,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -406,6 +442,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -424,6 +468,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -572,6 +620,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -610,8 +664,20 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -630,6 +696,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -658,6 +736,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -244,6 +244,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -280,6 +286,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -297,6 +308,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -369,6 +385,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -394,6 +415,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -403,6 +429,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -433,6 +464,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -531,6 +567,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -553,6 +597,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -745,6 +793,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -795,6 +849,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
@@ -803,6 +863,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -831,6 +897,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -855,6 +933,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -260,6 +260,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -296,6 +302,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -313,6 +324,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -385,6 +401,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -415,6 +436,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -424,6 +450,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -454,6 +485,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -552,6 +588,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -574,6 +618,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -770,6 +818,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -820,6 +874,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -834,6 +894,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -862,6 +928,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -886,6 +964,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -280,6 +280,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -328,6 +334,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -350,6 +361,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -432,6 +448,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -462,6 +483,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -476,6 +502,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -511,6 +542,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -614,6 +650,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -636,6 +680,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -864,6 +912,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -920,6 +974,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
 				bias-pull-up;
@@ -944,6 +1004,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -964,6 +1030,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1000,6 +1078,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -296,6 +296,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -344,6 +350,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -366,6 +377,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -453,6 +469,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -488,6 +509,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -502,6 +528,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -537,6 +568,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -640,6 +676,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -662,6 +706,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -894,6 +942,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -956,6 +1010,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -986,6 +1046,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1006,6 +1072,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1042,6 +1120,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -192,6 +192,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -216,8 +222,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -255,6 +271,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -275,6 +296,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -284,6 +310,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -299,6 +330,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -364,6 +400,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -386,6 +430,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -510,6 +558,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -548,6 +602,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -560,6 +620,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -568,6 +634,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -592,6 +664,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -176,6 +176,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -194,8 +200,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -233,6 +249,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -248,6 +269,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -257,6 +283,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -272,6 +303,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -337,6 +373,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -355,6 +399,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -471,6 +519,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -509,6 +563,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -521,6 +581,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -529,6 +595,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -553,6 +625,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -192,6 +192,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -216,8 +222,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -255,6 +271,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -275,6 +296,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -284,6 +310,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -299,6 +330,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -364,6 +400,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -386,6 +430,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -510,6 +558,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -548,6 +602,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -560,6 +620,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -568,6 +634,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -592,6 +664,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -176,6 +176,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c4_sda_pb7: i2c4_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 				bias-pull-up;
@@ -194,8 +200,18 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -233,6 +249,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -248,6 +269,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -257,6 +283,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -272,6 +303,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -337,6 +373,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -355,6 +399,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -471,6 +519,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -509,6 +563,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -521,6 +581,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -529,6 +595,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -553,6 +625,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -250,6 +250,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -280,6 +286,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -292,6 +303,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -364,6 +380,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -384,6 +405,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -398,6 +424,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -418,6 +449,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -501,6 +537,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -523,6 +567,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -691,6 +739,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -735,6 +789,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -753,6 +813,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -767,6 +833,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -799,6 +877,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -250,6 +250,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -280,6 +286,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -287,6 +298,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -354,6 +370,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -374,6 +395,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -391,6 +417,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
 				slew-rate = "very-high-speed";
@@ -403,6 +434,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -478,6 +514,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -500,6 +544,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -668,6 +716,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -712,6 +766,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -730,6 +790,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -744,6 +810,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -776,6 +854,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -260,6 +260,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -296,6 +302,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -313,6 +324,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -385,6 +401,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -415,6 +436,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -424,6 +450,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -454,6 +485,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -552,6 +588,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -574,6 +618,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -770,6 +818,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -820,6 +874,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -834,6 +894,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -862,6 +928,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -886,6 +964,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -296,6 +296,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -344,6 +350,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -366,6 +377,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -448,6 +464,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -483,6 +504,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -497,6 +523,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -532,6 +563,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -635,6 +671,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -657,6 +701,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -861,6 +909,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -917,6 +971,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -947,6 +1007,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -967,6 +1033,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1003,6 +1081,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -284,6 +284,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -332,6 +338,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -354,6 +365,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -436,6 +452,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -471,6 +492,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -485,6 +511,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -520,6 +551,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -623,6 +659,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -645,6 +689,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -849,6 +897,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -905,6 +959,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -935,6 +995,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -955,6 +1021,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -991,6 +1069,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -246,6 +246,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -276,6 +282,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -283,6 +294,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -340,6 +356,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -360,6 +381,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -369,6 +395,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -384,6 +415,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -454,6 +490,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -476,6 +520,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -632,6 +680,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -670,6 +724,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -678,6 +738,12 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -696,6 +762,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -724,6 +802,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -238,6 +238,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -268,6 +274,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -275,6 +286,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -332,6 +348,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -352,6 +373,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -361,6 +387,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -376,6 +407,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -446,6 +482,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -468,6 +512,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -624,6 +672,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -662,6 +716,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -674,6 +734,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -682,6 +748,18 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -710,6 +788,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -214,6 +214,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -238,6 +244,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pb14: spi2_miso_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 				bias-pull-down;
@@ -245,6 +256,11 @@
 
 			spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -302,6 +318,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -309,6 +330,11 @@
 
 			spi3_nss_pa4: spi3_nss_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 				bias-pull-up;
 			};
 
@@ -324,6 +350,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
 				slew-rate = "very-high-speed";
@@ -336,6 +367,11 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -406,6 +442,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -424,6 +468,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -572,6 +620,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -610,8 +664,20 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -630,6 +696,18 @@
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -658,6 +736,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -260,6 +260,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -296,6 +302,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -313,6 +324,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -385,6 +401,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -415,6 +436,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -424,6 +450,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -454,6 +485,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -552,6 +588,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -574,6 +618,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -770,6 +818,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -820,6 +874,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -834,6 +894,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -862,6 +928,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -886,6 +964,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -244,6 +244,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -280,6 +286,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -297,6 +308,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -369,6 +385,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -394,6 +415,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SCK */
 
 			spi1_sck_pa1: spi1_sck_pa1 {
@@ -403,6 +429,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -433,6 +464,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -531,6 +567,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -553,6 +597,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -745,6 +793,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -795,6 +849,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
@@ -803,6 +863,12 @@
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -831,6 +897,18 @@
 				drive-open-drain;
 			};
 
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
@@ -855,6 +933,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -296,6 +296,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -344,6 +350,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -366,6 +377,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -453,6 +469,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -488,6 +509,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -502,6 +528,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -537,6 +568,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -640,6 +676,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -662,6 +706,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -894,6 +942,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -956,6 +1010,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
 				bias-pull-up;
@@ -986,6 +1046,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -1006,6 +1072,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1042,6 +1120,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -280,6 +280,12 @@
 				drive-open-drain;
 			};
 
+			i2c3_sda_pb4: i2c3_sda_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c3_sda_pc1: i2c3_sda_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
 				bias-pull-up;
@@ -328,6 +334,11 @@
 				bias-pull-down;
 			};
 
+			spi1_miso_pb4: spi1_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				bias-pull-down;
+			};
+
 			spi1_miso_pe14: spi1_miso_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF5)>;
 				bias-pull-down;
@@ -350,6 +361,11 @@
 
 			spi2_miso_pd3: spi2_miso_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_pb4: spi3_miso_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
 			};
 
@@ -432,6 +448,11 @@
 				bias-pull-up;
 			};
 
+			spi1_nss_pa15: spi1_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				bias-pull-up;
+			};
+
 			spi1_nss_pb0: spi1_nss_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 				bias-pull-up;
@@ -462,6 +483,11 @@
 				bias-pull-up;
 			};
 
+			spi3_nss_pa15: spi3_nss_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_pg12: spi3_nss_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF6)>;
 				bias-pull-up;
@@ -476,6 +502,11 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi1_sck_pb3: spi1_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -511,6 +542,11 @@
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			spi3_sck_pb3: spi3_sck_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF6)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -614,6 +650,14 @@
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF1)>;
+			};
+
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
@@ -636,6 +680,10 @@
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
+			};
+
+			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
@@ -864,6 +912,12 @@
 				drive-open-drain;
 			};
 
+			usart1_cts_pb4: usart1_cts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
 				bias-pull-up;
@@ -920,6 +974,12 @@
 				drive-open-drain;
 			};
 
+			usart1_rts_pb3: usart1_rts_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
 				bias-pull-up;
@@ -944,6 +1004,12 @@
 				drive-open-drain;
 			};
 
+			usart3_rts_pa15: usart3_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
 				bias-pull-up;
@@ -964,6 +1030,18 @@
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_rts_pb4: uart5_rts_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1000,6 +1078,10 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -374,7 +374,7 @@ def get_mcu_signals(cube_path, gpio_ip_afs):
 
             # obtain pin port (A, B, ...) and number (0, 1, ...)
             pin_name = pin.get("Name")
-            m = re.search(r"^P([A-Z])(\d+)$", pin_name)
+            m = re.search(r"^P([A-Z])(\d+).*$", pin_name)
             if not m:
                 continue
 

--- a/scripts/tests/genpinctrl/data/cubemx/db/mcu/STM32F0TESTDIE.xml
+++ b/scripts/tests/genpinctrl/data/cubemx/db/mcu/STM32F0TESTDIE.xml
@@ -8,7 +8,7 @@
     <Pin Name="WRONG_NAME" Type="I/O">
     </Pin>
     <!-- Valid pin (not in IP) -->
-    <Pin Name="PA1" Type="I/O">
+    <Pin Name="PA1 (TEST)" Type="I/O">
     </Pin>
     <!-- Valid pin -->
     <Pin Name="PA0" Type="I/O">


### PR DESCRIPTION
Some pin names have another name appended, e.g. "PA15 (JTDI)".  Current regex did not handle those cases, so it has been adjusted to handle them.