### PR TITLE
pins: dts: Add missing USB_OTG_FS_ID pin

### DIFF
--- a/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
@@ -797,6 +797,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
@@ -797,6 +797,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f205rgex-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205rgex-pinctrl.dtsi
@@ -797,6 +797,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -900,6 +900,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -993,6 +993,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -1106,6 +1106,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -1106,6 +1106,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -900,6 +900,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -993,6 +993,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
@@ -797,6 +797,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -900,6 +900,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -993,6 +993,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -1106,6 +1106,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -1106,6 +1106,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -900,6 +900,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -993,6 +993,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
@@ -475,6 +475,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
@@ -475,6 +475,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
@@ -475,6 +475,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
@@ -475,6 +475,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
@@ -475,6 +475,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
@@ -567,6 +567,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
@@ -567,6 +567,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
@@ -708,6 +708,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
@@ -698,6 +698,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
@@ -708,6 +708,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
@@ -698,6 +698,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
@@ -894,6 +894,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
@@ -815,6 +815,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -918,6 +918,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -1011,6 +1011,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -1128,6 +1128,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -1128,6 +1128,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -918,6 +918,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -1011,6 +1011,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
@@ -602,6 +602,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
@@ -602,6 +602,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
@@ -703,6 +703,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
@@ -932,6 +932,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
@@ -922,6 +922,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
@@ -687,6 +687,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
@@ -829,6 +829,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
@@ -829,6 +829,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
@@ -829,6 +829,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
@@ -1087,6 +1087,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
@@ -1078,6 +1078,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
@@ -1187,6 +1187,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
@@ -1187,6 +1187,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
@@ -805,6 +805,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
@@ -1071,6 +1071,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
@@ -965,6 +965,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -1264,6 +1264,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -1409,6 +1409,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -1409,6 +1409,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
@@ -894,6 +894,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
@@ -815,6 +815,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -918,6 +918,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -1011,6 +1011,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -1128,6 +1128,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -1128,6 +1128,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -918,6 +918,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -1011,6 +1011,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f423chux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423chux-pinctrl.dtsi
@@ -805,6 +805,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
@@ -1071,6 +1071,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
@@ -965,6 +965,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -1264,6 +1264,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -1409,6 +1409,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -1409,6 +1409,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -1177,6 +1177,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -994,6 +994,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -1141,6 +1141,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -1177,6 +1177,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -994,6 +994,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -994,6 +994,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -1141,6 +1141,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -1141,6 +1141,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -1141,6 +1141,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -1141,6 +1141,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -1177,6 +1177,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -994,6 +994,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -1141,6 +1141,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -1177,6 +1177,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -994,6 +994,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -1141,6 +1141,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -1141,6 +1141,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -1006,6 +1006,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -946,6 +946,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -1139,6 +1139,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -1266,6 +1266,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -1266,6 +1266,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -1266,6 +1266,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -1136,6 +1136,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -1136,6 +1136,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -1291,6 +1291,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -1244,6 +1244,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -1244,6 +1244,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -1244,6 +1244,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -1291,6 +1291,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -1291,6 +1291,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -944,6 +944,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -944,6 +944,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -1058,6 +1058,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -1058,6 +1058,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -1136,6 +1136,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -1136,6 +1136,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -1291,6 +1291,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -1244,6 +1244,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -1244,6 +1244,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -1291,6 +1291,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -944,6 +944,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -1058,6 +1058,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1373,6 +1373,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1373,6 +1373,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -873,6 +873,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -1084,6 +1084,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -1223,6 +1223,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1329,6 +1329,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1329,6 +1329,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -1031,6 +1031,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -1179,6 +1179,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -1179,6 +1179,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1329,6 +1329,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -873,6 +873,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -1084,6 +1084,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -1179,6 +1179,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1373,6 +1373,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1373,6 +1373,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -873,6 +873,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -1084,6 +1084,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -1223,6 +1223,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1329,6 +1329,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1329,6 +1329,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -1031,6 +1031,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -1179,6 +1179,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -1179,6 +1179,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -1114,6 +1114,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -1114,6 +1114,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1285,6 +1285,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -1114,6 +1114,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -1114,6 +1114,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -1114,6 +1114,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1285,6 +1285,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1285,6 +1285,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1285,6 +1285,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -1114,6 +1114,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1285,6 +1285,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -1429,6 +1429,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -1114,6 +1114,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -1114,6 +1114,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1285,6 +1285,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1285,6 +1285,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -1307,6 +1307,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -1307,6 +1307,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -1501,6 +1501,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -1307,6 +1307,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -1307,6 +1307,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -1307,6 +1307,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -1307,6 +1307,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -1501,6 +1501,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -1501,6 +1501,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -1496,6 +1496,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -1496,6 +1496,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -1590,6 +1590,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -1590,6 +1590,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -1307,6 +1307,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -1307,6 +1307,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -1501,6 +1501,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -1496,6 +1496,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -1496,6 +1496,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -1590,6 +1590,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -1663,6 +1663,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -1655,6 +1655,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -1811,6 +1811,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -1716,6 +1716,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -1716,6 +1716,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -1300,6 +1300,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -1300,6 +1300,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -1542,6 +1542,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -1655,6 +1655,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -1811,6 +1811,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -1811,6 +1811,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -1726,6 +1726,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -1726,6 +1726,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -1726,6 +1726,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -1726,6 +1726,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -1300,6 +1300,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -1300,6 +1300,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -1300,6 +1300,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -1542,6 +1542,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1542,6 +1542,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -1811,6 +1811,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -1811,6 +1811,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -1734,6 +1734,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -1619,6 +1619,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -1734,6 +1734,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -1619,6 +1619,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -1496,6 +1496,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -1496,6 +1496,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -1542,6 +1542,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -1726,6 +1726,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -1726,6 +1726,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -1542,6 +1542,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -1542,6 +1542,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1381,6 +1381,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -1726,6 +1726,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -1716,6 +1716,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -1300,6 +1300,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -1542,6 +1542,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -1655,6 +1655,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -1811,6 +1811,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -1726,6 +1726,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -1726,6 +1726,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -1300,6 +1300,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -1300,6 +1300,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -1542,6 +1542,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -1811,6 +1811,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -1734,6 +1734,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -1619,6 +1619,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -1496,6 +1496,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -1542,6 +1542,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -1726,6 +1726,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -1542,6 +1542,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -1875,6 +1875,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1381,6 +1381,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -839,6 +839,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -998,6 +998,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -904,6 +904,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -877,6 +877,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -937,6 +937,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -1140,6 +1140,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -839,6 +839,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -998,6 +998,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -1184,6 +1184,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -1184,6 +1184,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -1165,6 +1165,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -904,6 +904,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -904,6 +904,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -1140,6 +1140,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -839,6 +839,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -998,6 +998,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -1184,6 +1184,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -1407,6 +1407,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -1403,6 +1403,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -1302,6 +1302,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -1271,6 +1271,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -972,6 +972,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -950,6 +950,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -1148,6 +1148,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -1145,6 +1145,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -1133,6 +1133,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -1346,6 +1346,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -1321,6 +1321,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -1407,6 +1407,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -1403,6 +1403,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -1302,6 +1302,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -1271,6 +1271,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -972,6 +972,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -950,6 +950,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -1148,6 +1148,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -1145,6 +1145,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -1133,6 +1133,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -1346,6 +1346,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -1321,6 +1321,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -1350,6 +1350,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -1346,6 +1346,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -735,6 +735,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -735,6 +735,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -691,6 +691,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -691,6 +691,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -1249,6 +1249,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -1218,6 +1218,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -905,6 +905,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -887,6 +887,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -1107,6 +1107,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -1104,6 +1104,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -1078,6 +1078,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -1092,6 +1092,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -1248,6 +1248,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -1286,6 +1286,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -735,6 +735,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -735,6 +735,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -1249,6 +1249,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -905,6 +905,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -1107,6 +1107,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -1104,6 +1104,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -1273,6 +1273,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -1286,6 +1286,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -1185,6 +1185,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -1043,6 +1043,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -1209,6 +1209,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -1176,6 +1176,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -1184,6 +1184,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -1286,6 +1286,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -1043,6 +1043,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -1209,6 +1209,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -1266,6 +1266,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -995,6 +995,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -1188,6 +1188,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -1177,6 +1177,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -1176,6 +1176,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -1145,6 +1145,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -1286,6 +1286,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -1185,6 +1185,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -1043,6 +1043,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -1209,6 +1209,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -1176,6 +1176,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -1286,6 +1286,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -1043,6 +1043,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -1209,6 +1209,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -1266,6 +1266,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -995,6 +995,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -1188,6 +1188,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -1177,6 +1177,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -1176,6 +1176,13 @@
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
+			/* USB_OTG_FS_ID */
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+				bias-pull-up;
+			};
+
 		};
 	};
 };

--- a/scripts/genpinctrl/config-f1.yaml
+++ b/scripts/genpinctrl/config-f1.yaml
@@ -136,11 +136,3 @@
 - name: UART_RX / USART_RX
   match: "^US?ART\\d+_RX$"
   mode: input
-
-- name: USB_OTG_FS_DM
-  match: "^USB_OTG_FS_DM$"
-  mode: alternate
-
-- name: USB_OTG_FS_DP
-  match: "^USB_OTG_FS_DP$"
-  mode: alternate

--- a/scripts/genpinctrl/config.yaml
+++ b/scripts/genpinctrl/config.yaml
@@ -136,3 +136,8 @@
 - name: USB_OTG_FS_DP
   match: "^USB_OTG_FS_DP$"
   mode: alternate
+
+- name: USB_OTG_FS_ID
+  match: "^USB_OTG_FS_ID$"
+  mode: alternate
+  bias: pull-up


### PR DESCRIPTION
Add USB_OTG_FS_ID to config.yaml and re-gen dts pinctrl.dtsi files

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>