### PR TITLE
pins: dts: Fix regex to support CAN_{TX,RX} and CANn_{TX,RX}

### DIFF
--- a/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f042f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f4px-pinctrl.dtsi
@@ -48,6 +48,24 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f042f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f6px-pinctrl.dtsi
@@ -48,6 +48,24 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,24 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,24 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,24 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
@@ -52,6 +52,24 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
@@ -52,6 +52,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
@@ -52,6 +52,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
@@ -52,6 +52,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f072rbix-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbix-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
@@ -76,6 +76,37 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF0)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF0)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,37 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF0)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF0)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
@@ -52,6 +52,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
@@ -52,6 +52,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f091rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rchx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
@@ -76,6 +76,37 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF0)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF0)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f091vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091vchx-pinctrl.dtsi
@@ -76,6 +76,37 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF0)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF0)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f098cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098cctx-pinctrl.dtsi
@@ -52,6 +52,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f098ccux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098ccux-pinctrl.dtsi
@@ -52,6 +52,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f098rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rchx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f098rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rctx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f098vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vchx-pinctrl.dtsi
@@ -76,6 +76,37 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF0)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF0)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f098vctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vctx-pinctrl.dtsi
@@ -76,6 +76,37 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF4)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF0)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF0)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -92,6 +92,26 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -92,6 +92,26 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -92,6 +92,26 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -92,6 +92,26 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -132,6 +132,26 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -140,6 +140,26 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -132,6 +132,26 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -140,6 +140,26 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -172,6 +172,26 @@
 				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -160,6 +160,26 @@
 				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -172,6 +172,26 @@
 				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -92,6 +92,18 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -92,6 +92,18 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -140,6 +140,34 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -140,6 +140,34 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -172,6 +172,34 @@
 				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -172,6 +172,34 @@
 				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -172,6 +172,34 @@
 				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -140,6 +140,34 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -192,6 +192,34 @@
 				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -192,6 +192,34 @@
 				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -192,6 +192,34 @@
 				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -192,6 +192,34 @@
 				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
@@ -56,6 +56,28 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
@@ -48,6 +48,28 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
@@ -56,6 +56,28 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
@@ -44,6 +44,19 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
@@ -72,6 +72,28 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
@@ -92,6 +92,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
@@ -96,6 +96,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
@@ -100,6 +100,37 @@
 				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -104,6 +104,37 @@
 				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -104,6 +104,37 @@
 				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
@@ -96,6 +96,37 @@
 				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -108,6 +108,37 @@
 				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
@@ -72,6 +72,28 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
@@ -72,6 +72,28 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
@@ -88,6 +88,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
@@ -52,6 +52,19 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
@@ -48,6 +48,19 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
@@ -112,6 +112,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
@@ -116,6 +116,28 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
@@ -120,6 +120,28 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
@@ -212,6 +212,37 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -216,6 +216,37 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -216,6 +216,37 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
@@ -184,6 +184,37 @@
 				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f303veyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303veyx-pinctrl.dtsi
@@ -192,6 +192,37 @@
 				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -220,6 +220,37 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
@@ -68,6 +68,28 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
@@ -72,6 +72,28 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
@@ -88,6 +88,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
@@ -52,6 +52,19 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
@@ -48,6 +48,19 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
@@ -112,6 +112,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f358cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358cctx-pinctrl.dtsi
@@ -68,6 +68,28 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f358rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358rctx-pinctrl.dtsi
@@ -112,6 +112,28 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f358vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358vctx-pinctrl.dtsi
@@ -208,6 +208,37 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
@@ -48,6 +48,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
@@ -76,6 +76,37 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
@@ -76,6 +76,37 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f378cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378cctx-pinctrl.dtsi
@@ -48,6 +48,28 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f378rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rctx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
@@ -76,6 +76,28 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f378vchx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vchx-pinctrl.dtsi
@@ -76,6 +76,37 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f378vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vctx-pinctrl.dtsi
@@ -76,6 +76,37 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f3/stm32f398vetx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f398vetx-pinctrl.dtsi
@@ -212,6 +212,37 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* CAN_RX */
+
+			can_rx_pa11: can_rx_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pb8: can_rx_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF9)>;
+				bias-pull-up;
+			};
+
+			can_rx_pd0: can_rx_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF7)>;
+				bias-pull-up;
+			};
+
+			/* CAN_TX */
+
+			can_tx_pa12: can_tx_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF9)>;
+			};
+
+			can_tx_pb9: can_tx_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF9)>;
+			};
+
+			can_tx_pd1: can_tx_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF7)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/scripts/genpinctrl/config-f1.yaml
+++ b/scripts/genpinctrl/config-f1.yaml
@@ -39,11 +39,11 @@
   mode: analog
 
 - name: CAN_RX
-  match: "^CAN\\d+_RX$"
+  match: "^CAN\\d*_RX$"
   mode: input
 
 - name: CAN_TX
-  match: "^CAN\\d+_TX$"
+  match: "^CAN\\d*_TX$"
   mode: alternate
 
 - name: DAC_OUT

--- a/scripts/genpinctrl/config.yaml
+++ b/scripts/genpinctrl/config.yaml
@@ -36,12 +36,12 @@
   mode: analog
 
 - name: CAN_RX
-  match: "^CAN\\d+_RX$"
+  match: "^CAN\\d*_RX$"
   mode: alternate
   bias: pull-up
 
 - name: CAN_TX
-  match: "^CAN\\d+_TX$"
+  match: "^CAN\\d*_TX$"
   mode: alternate
 
 - name: DAC_OUT


### PR DESCRIPTION
Some SoCs have the CAN signals without a number identifier (CAN_TX,
CAN_RX) so tweak regex to support with and without a number id.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>