### PR TITLE
scripts: genpinctrl: use pathlib

### DIFF
--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -3,7 +3,7 @@ Utility to autogenerate Zephyr DT pinctrl files for all STM32 microcontrollers.
 
 Usage::
 
-    python3 genpinctrl.py -p /path/to/STM32CubeMX -o /path/to/output_dir
+    python3 genpinctrl.py [-p /path/to/STM32CubeMX] [-o /path/to/output_dir]
 
 Copyright (c) 2020 Teslabs Engineering S.L.
 
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 
 SCRIPT_DIR = Path(__file__).absolute().parent
 """Script directory."""
+
+REPO_ROOT = SCRIPT_DIR / ".." / ".."
+"""Repository root (used for defaults)."""
 
 CONFIG_FILE = SCRIPT_DIR / "stm32-pinctrl-config.yaml"
 """Configuration file."""
@@ -531,15 +534,15 @@ if __name__ == "__main__":
     parser.add_argument(
         "-p",
         "--cube-path",
-        required=True,
         type=Path,
+        default=Path.home() / "STM32CubeMX",
         help="CubeMX path",
     )
     parser.add_argument(
         "-o",
         "--output",
-        required=True,
         type=Path,
+        default=REPO_ROOT / "dts" / "st",
         help="Output directory",
     )
     args = parser.parse_args()

--- a/scripts/tests/genpinctrl/conftest.py
+++ b/scripts/tests/genpinctrl/conftest.py
@@ -1,20 +1,20 @@
-import os
+from pathlib import Path
 import sys
 
 import pytest
 
 
-_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.join(_SCRIPT_DIR, "..", "..", "genpinctrl"))
+_SCRIPT_DIR = Path(__file__).absolute().parent
+sys.path.insert(0, str(_SCRIPT_DIR / ".." / ".." / "genpinctrl"))
 
 
 @pytest.fixture()
 def data():
     """Pytest fixture to load test data files"""
-    return os.path.join(_SCRIPT_DIR, "data")
+    return _SCRIPT_DIR / "data"
 
 
 @pytest.fixture()
 def cubemx(data):
     """Pytest fixture to load test CubeMX files"""
-    return os.path.join(data, "cubemx")
+    return data / "cubemx"

--- a/scripts/tests/genpinctrl/test_genpinctrl.py
+++ b/scripts/tests/genpinctrl/test_genpinctrl.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -219,10 +219,10 @@ def test_cubemx_missing():
     """Test that missing CubeMX folders is handled correctly by parsing functions."""
 
     with pytest.raises(FileNotFoundError):
-        get_gpio_ip_afs("MISSING_PATH")
+        get_gpio_ip_afs(Path("MISSING_PATH"))
 
     with pytest.raises(FileNotFoundError):
-        get_mcu_signals("MISSING_PATH", dict())
+        get_mcu_signals(Path("MISSING_PATH"), dict())
 
 
 def test_main(data, cubemx, tmp_path):
@@ -231,19 +231,19 @@ def test_main(data, cubemx, tmp_path):
     main(cubemx, tmp_path)
 
     # check f0 file
-    ref_pinctrl_file = os.path.join(data, "stm32f0testdie-pinctrl.dtsi")
-    gen_pinctrl_file = os.path.join(tmp_path, "f0", "stm32f0testdie-pinctrl.dtsi")
+    ref_pinctrl_file = data / "stm32f0testdie-pinctrl.dtsi"
+    gen_pinctrl_file = tmp_path / "f0" / "stm32f0testdie-pinctrl.dtsi"
 
-    assert os.path.exists(gen_pinctrl_file)
+    assert gen_pinctrl_file.exists()
 
     with open(ref_pinctrl_file) as ref, open(gen_pinctrl_file) as gen:
         assert ref.read() == gen.read()
 
     # check f1 file
-    ref_pinctrl_file = os.path.join(data, "stm32f1testdie-pinctrl.dtsi")
-    gen_pinctrl_file = os.path.join(tmp_path, "f1", "stm32f1testdie-pinctrl.dtsi")
+    ref_pinctrl_file = data / "stm32f1testdie-pinctrl.dtsi"
+    gen_pinctrl_file = tmp_path / "f1" / "stm32f1testdie-pinctrl.dtsi"
 
-    assert os.path.exists(gen_pinctrl_file)
+    assert gen_pinctrl_file.exists()
 
     with open(ref_pinctrl_file) as ref, open(gen_pinctrl_file) as gen:
         assert ref.read() == gen.read()


### PR DESCRIPTION
Use pathlib facilities to improve path handling. Also added defaults to make it easier to use the script.
