### PR TITLE
scripts: genpinctrl: fix multiple F1 issues

### DIFF
--- a/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
@@ -180,16 +180,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -216,32 +232,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -256,8 +304,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
@@ -280,12 +280,20 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
+			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+			};
+
+			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
@@ -296,11 +304,21 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -309,6 +327,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
@@ -74,6 +74,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -83,6 +88,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -98,6 +108,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -106,6 +121,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -118,6 +137,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -126,6 +149,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -138,6 +165,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -146,6 +177,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -160,6 +195,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -168,6 +208,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -296,12 +340,20 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
+			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+			};
+
+			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
@@ -312,11 +364,21 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -331,6 +393,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
@@ -224,16 +224,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -260,32 +276,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -300,8 +348,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -392,6 +448,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -404,6 +466,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
@@ -316,12 +316,20 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
+			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+			};
+
+			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
@@ -332,11 +340,21 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -345,6 +363,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
@@ -200,16 +200,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -236,32 +252,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -276,8 +324,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
@@ -204,16 +204,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -240,32 +256,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -280,8 +328,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
@@ -320,12 +320,20 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
+			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+			};
+
+			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
@@ -336,11 +344,21 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -349,6 +367,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
@@ -244,16 +244,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -280,32 +296,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -320,8 +368,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -428,6 +484,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -440,6 +502,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
@@ -94,6 +94,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -103,6 +108,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -118,6 +128,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -126,6 +141,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -138,6 +157,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -146,6 +169,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -158,6 +185,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -166,6 +197,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -180,6 +215,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -188,6 +228,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -332,12 +376,20 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
+			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+			};
+
+			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
@@ -348,11 +400,21 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -367,6 +429,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -107,6 +112,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -122,6 +132,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -130,6 +145,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -142,6 +161,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -150,6 +173,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -162,6 +189,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -170,6 +201,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -184,6 +219,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -192,6 +232,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -336,12 +380,20 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
+			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+			};
+
+			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
@@ -352,11 +404,21 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -371,6 +433,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
@@ -248,16 +248,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -284,32 +300,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -324,8 +372,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -432,6 +488,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -444,6 +506,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -107,6 +112,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -122,6 +132,16 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_master_pb4: spi3_miso_master_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -130,6 +150,14 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -142,6 +170,14 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_nss_master_pa15: spi3_nss_master_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -150,6 +186,14 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_sck_master_pb3: spi3_sck_master_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -162,6 +206,14 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -170,6 +222,14 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -184,6 +244,16 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -192,6 +262,14 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+			};
+
+			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -356,7 +434,19 @@
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
@@ -364,8 +454,16 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+			};
+
+			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
@@ -376,6 +474,10 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
 			};
 
+			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
 			};
@@ -384,11 +486,21 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -403,6 +515,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -434,6 +550,14 @@
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -454,6 +578,14 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
@@ -282,16 +282,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -318,32 +334,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim12_ch1_pwm_pb12: tim12_ch1_pwm_pb12 {
@@ -378,8 +426,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -514,6 +570,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -526,6 +588,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
@@ -248,16 +248,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -312,32 +328,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -352,8 +400,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -482,6 +538,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -504,6 +566,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -107,6 +112,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -122,6 +132,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -130,6 +145,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -142,6 +161,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -150,6 +173,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -162,6 +189,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -170,6 +201,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -184,6 +219,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -192,6 +232,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -380,12 +424,20 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
+			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+			};
+
+			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
@@ -396,11 +448,21 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -427,6 +489,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
@@ -282,16 +282,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -346,32 +362,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim12_ch1_pwm_pb12: tim12_ch1_pwm_pb12 {
@@ -406,8 +454,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -564,6 +620,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -586,6 +648,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -107,6 +112,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -122,6 +132,16 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_master_pb4: spi3_miso_master_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -130,6 +150,14 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -142,6 +170,14 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_nss_master_pa15: spi3_nss_master_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -150,6 +186,14 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_sck_master_pb3: spi3_sck_master_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -162,6 +206,14 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -170,6 +222,14 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -184,6 +244,16 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -192,6 +262,14 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+			};
+
+			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -400,7 +478,19 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
@@ -408,8 +498,16 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+			};
+
+			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
@@ -420,6 +518,10 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
 			};
 
+			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
 			};
@@ -428,11 +530,21 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -459,6 +571,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -506,6 +622,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -534,6 +658,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
@@ -282,16 +282,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -346,32 +362,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim12_ch1_pwm_pb12: tim12_ch1_pwm_pb12 {
@@ -406,8 +454,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -564,6 +620,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -586,6 +648,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -107,6 +112,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -122,6 +132,16 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
+			spi3_miso_master_pb4: spi3_miso_master_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -130,6 +150,14 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -142,6 +170,14 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_nss_master_pa15: spi3_nss_master_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -150,6 +186,14 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_sck_master_pb3: spi3_sck_master_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -162,6 +206,14 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -170,6 +222,14 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -184,6 +244,16 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
+			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -192,6 +262,14 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+			};
+
+			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -400,7 +478,19 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
@@ -408,8 +498,16 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+			};
+
+			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
@@ -420,6 +518,10 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
 			};
 
+			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
 			};
@@ -428,11 +530,21 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
 			};
 
+			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -459,6 +571,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -506,6 +622,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -534,6 +658,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
@@ -220,6 +220,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -227,6 +233,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
@@ -166,32 +166,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -206,8 +238,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
@@ -64,6 +64,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -73,6 +78,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -88,6 +98,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -96,6 +111,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -108,6 +127,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -116,6 +139,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -128,6 +155,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -136,6 +167,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -150,6 +185,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -158,6 +198,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -236,6 +280,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -249,6 +299,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
@@ -210,32 +210,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -250,8 +282,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -298,6 +338,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -310,6 +356,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
@@ -64,6 +64,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -73,6 +78,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -88,6 +98,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -96,6 +111,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -108,6 +127,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -116,6 +139,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -128,6 +155,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -136,6 +167,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -150,6 +185,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -158,6 +198,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -236,6 +280,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -249,6 +299,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
@@ -210,32 +210,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -250,8 +282,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -298,6 +338,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -310,6 +356,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
@@ -260,6 +260,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -267,6 +273,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
@@ -190,32 +190,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -230,8 +262,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
@@ -88,6 +88,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -97,6 +102,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -112,6 +122,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -120,6 +135,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -132,6 +151,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -140,6 +163,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -152,6 +179,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -160,6 +191,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -174,6 +209,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -182,6 +222,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -276,6 +320,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -289,6 +339,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
@@ -234,32 +234,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -274,8 +306,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -338,6 +378,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -350,6 +396,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -110,6 +115,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
@@ -119,6 +129,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -137,6 +152,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -149,6 +168,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -165,6 +188,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -179,6 +206,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -191,6 +222,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -209,6 +244,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -222,6 +262,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -318,7 +362,29 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -333,6 +399,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -364,6 +434,14 @@
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -384,6 +462,14 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
@@ -278,32 +278,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -318,8 +350,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -398,6 +438,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -410,6 +456,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
@@ -286,32 +286,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -338,8 +370,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -430,6 +470,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -442,6 +488,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -110,6 +115,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
@@ -119,6 +129,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -137,6 +152,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -149,6 +168,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -165,6 +188,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -179,6 +206,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -191,6 +222,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -209,6 +244,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -222,6 +262,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -268,6 +312,14 @@
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
@@ -334,6 +386,22 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
@@ -343,6 +411,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -357,6 +431,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -388,6 +466,14 @@
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -408,6 +494,14 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
@@ -230,32 +230,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -270,8 +302,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -334,6 +374,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -346,6 +392,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
@@ -84,6 +84,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -93,6 +98,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -108,6 +118,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -116,6 +131,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -128,6 +147,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -136,6 +159,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -148,6 +175,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -156,6 +187,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -170,6 +205,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -178,6 +218,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -272,6 +316,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -285,6 +335,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
@@ -156,24 +156,48 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -188,8 +212,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
@@ -202,6 +202,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -209,6 +215,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
@@ -210,6 +210,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -217,6 +223,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
@@ -156,24 +156,48 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -188,8 +212,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
@@ -88,6 +88,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -97,6 +102,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -112,6 +122,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -120,6 +135,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -132,6 +151,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -140,6 +163,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -152,6 +179,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -160,6 +191,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -174,6 +209,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -182,6 +222,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -292,6 +336,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -317,6 +367,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
@@ -234,32 +234,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -274,8 +306,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -360,6 +400,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -382,6 +428,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
@@ -278,32 +278,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -318,8 +350,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -420,6 +460,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -442,6 +488,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -110,6 +115,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
@@ -119,6 +129,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -137,6 +152,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -149,6 +168,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -165,6 +188,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -179,6 +206,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -191,6 +222,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -209,6 +244,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -222,6 +262,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -334,7 +378,29 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -361,6 +427,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -408,6 +478,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -436,6 +514,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
@@ -286,32 +286,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -338,8 +370,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -460,6 +500,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -482,6 +528,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -110,6 +115,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
@@ -119,6 +129,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -137,6 +152,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -149,6 +168,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -165,6 +188,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -179,6 +206,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -191,6 +222,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -209,6 +244,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -222,6 +262,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -268,6 +312,14 @@
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
@@ -350,6 +402,22 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
@@ -367,6 +435,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -393,6 +467,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -440,6 +518,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -468,6 +554,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
@@ -278,32 +278,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -318,8 +350,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -420,6 +460,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -442,6 +488,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -110,6 +115,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
@@ -119,6 +129,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -137,6 +152,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -149,6 +168,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -165,6 +188,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -179,6 +206,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -191,6 +222,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -209,6 +244,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -222,6 +262,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -334,7 +378,29 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -361,6 +427,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -408,6 +478,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -436,6 +514,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
@@ -294,32 +294,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -346,8 +378,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -476,6 +516,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -498,6 +544,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
@@ -98,6 +98,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -110,6 +115,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
@@ -119,6 +129,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -137,6 +152,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -149,6 +168,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -165,6 +188,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -179,6 +206,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -191,6 +222,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -209,6 +244,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -222,6 +262,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -276,6 +320,14 @@
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
@@ -366,6 +418,22 @@
 				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
@@ -383,6 +451,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -409,6 +483,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -456,6 +534,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -484,6 +570,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -220,6 +220,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -227,6 +233,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -166,32 +166,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -206,8 +238,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -64,6 +64,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -73,6 +78,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -88,6 +98,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -96,6 +111,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -108,6 +127,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -116,6 +139,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -128,6 +155,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -136,6 +167,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -150,6 +185,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -158,6 +198,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -236,6 +280,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -249,6 +299,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -210,32 +210,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -250,8 +282,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -298,6 +338,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -310,6 +356,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -260,6 +260,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -267,6 +273,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -190,32 +190,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -230,8 +262,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -88,6 +88,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -97,6 +102,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -112,6 +122,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -120,6 +135,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -132,6 +151,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -140,6 +163,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -152,6 +179,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -160,6 +191,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -174,6 +209,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -182,6 +222,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -276,6 +320,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -289,6 +339,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -234,32 +234,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -274,8 +306,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -338,6 +378,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -350,6 +396,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -320,6 +320,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -327,6 +333,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -230,16 +230,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -266,32 +282,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -306,8 +354,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -274,16 +274,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -310,32 +326,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -350,8 +398,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -398,6 +454,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -410,6 +472,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -124,6 +124,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -133,6 +138,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -148,6 +158,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -156,6 +171,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -168,6 +187,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -176,6 +199,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -188,6 +215,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -196,6 +227,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -210,6 +245,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -218,6 +258,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -336,6 +380,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -349,6 +399,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -320,6 +320,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -327,6 +333,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -230,16 +230,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -266,32 +282,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -306,8 +354,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -274,16 +274,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -310,32 +326,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -350,8 +398,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -398,6 +454,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -410,6 +472,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -124,6 +124,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -133,6 +138,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -148,6 +158,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -156,6 +171,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -168,6 +187,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -176,6 +199,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -188,6 +215,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -196,6 +227,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -210,6 +245,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -218,6 +258,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -336,6 +380,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -349,6 +399,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -270,16 +270,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -306,32 +322,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -346,8 +394,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -376,6 +376,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -383,6 +389,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -384,6 +384,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -391,6 +397,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -278,16 +278,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -314,32 +330,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -354,8 +402,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -314,16 +314,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -350,32 +366,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -390,8 +438,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -454,6 +510,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -466,6 +528,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -164,6 +164,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -173,6 +178,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -188,6 +198,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -196,6 +211,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -208,6 +227,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -216,6 +239,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -228,6 +255,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -236,6 +267,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -250,6 +285,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -258,6 +298,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -392,6 +436,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -405,6 +455,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -322,16 +322,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -358,32 +374,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -398,8 +446,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -462,6 +518,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -474,6 +536,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -172,6 +172,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -181,6 +186,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -196,6 +206,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -204,6 +219,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -216,6 +235,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -224,6 +247,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -236,6 +263,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -244,6 +275,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -258,6 +293,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -266,6 +306,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -400,6 +444,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -413,6 +463,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -214,6 +214,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -226,7 +231,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -234,11 +248,19 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
@@ -253,6 +275,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -271,6 +298,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -283,6 +314,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -299,6 +334,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -313,6 +352,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -325,6 +368,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -343,6 +390,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -356,6 +408,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -492,7 +548,57 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -507,6 +613,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -538,6 +648,14 @@
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -558,6 +676,14 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -428,16 +428,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -464,32 +480,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -504,8 +552,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -612,6 +668,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -624,6 +686,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -416,16 +416,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -452,32 +468,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -492,8 +540,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -600,6 +656,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -612,6 +674,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -202,6 +202,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -214,7 +219,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -222,11 +236,19 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
@@ -241,6 +263,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -259,6 +286,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -271,6 +302,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -287,6 +322,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -301,6 +340,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -313,6 +356,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -331,6 +378,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -344,6 +396,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -480,7 +536,57 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -495,6 +601,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -526,6 +636,14 @@
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -546,6 +664,14 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -214,6 +214,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -226,7 +231,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -234,11 +248,19 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
@@ -253,6 +275,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -271,6 +298,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -283,6 +314,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -299,6 +334,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -313,6 +352,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -325,6 +368,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -343,6 +390,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -356,6 +408,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -444,6 +500,14 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
 			};
 
+			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
 			};
@@ -508,6 +572,50 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
@@ -517,6 +625,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -531,6 +645,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -562,6 +680,14 @@
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -582,6 +708,14 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -432,16 +432,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -472,32 +488,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -524,8 +572,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -644,6 +700,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -656,6 +718,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -212,16 +212,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -236,24 +252,48 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -268,8 +308,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -282,6 +282,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -289,6 +295,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -212,16 +212,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -236,24 +252,48 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -268,8 +308,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -290,6 +290,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -297,6 +303,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -180,6 +180,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -189,6 +194,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -204,6 +214,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -212,6 +227,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -224,6 +243,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -232,6 +255,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -244,6 +271,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -252,6 +283,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -266,6 +301,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -274,6 +314,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -452,6 +496,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -477,6 +527,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -330,16 +330,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -394,32 +410,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -434,8 +482,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -520,6 +576,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -542,6 +604,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -180,6 +180,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -189,6 +194,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -204,6 +214,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -212,6 +227,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -224,6 +243,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -232,6 +255,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -244,6 +271,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -252,6 +283,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -266,6 +301,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -274,6 +314,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -452,6 +496,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -477,6 +527,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -330,16 +330,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -394,32 +410,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -434,8 +482,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -520,6 +576,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -542,6 +604,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -222,6 +222,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -234,7 +239,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -242,11 +256,19 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
@@ -261,6 +283,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -279,6 +306,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -291,6 +322,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -307,6 +342,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -321,6 +360,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -333,6 +376,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -351,6 +398,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -364,6 +416,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -544,7 +600,57 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -571,6 +677,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -618,6 +728,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -646,6 +764,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -436,16 +436,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -500,32 +516,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -540,8 +588,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -670,6 +726,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -692,6 +754,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -222,6 +222,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -234,7 +239,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -242,11 +256,19 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
@@ -261,6 +283,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -279,6 +306,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -291,6 +322,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -307,6 +342,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -321,6 +360,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -333,6 +376,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -351,6 +398,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -364,6 +416,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -544,7 +600,57 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -571,6 +677,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -618,6 +728,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -646,6 +764,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -436,16 +436,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -500,32 +516,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -540,8 +588,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -670,6 +726,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -692,6 +754,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -440,16 +440,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -508,32 +524,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -560,8 +608,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -710,6 +766,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -732,6 +794,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -222,6 +222,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -234,7 +239,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -242,11 +256,19 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
@@ -261,6 +283,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -279,6 +306,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -291,6 +322,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -307,6 +342,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -321,6 +360,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -333,6 +376,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -351,6 +398,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -364,6 +416,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -480,6 +536,14 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
 			};
 
+			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
 			};
@@ -560,6 +624,50 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
@@ -577,6 +685,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -603,6 +717,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -650,6 +768,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -678,6 +804,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -180,6 +180,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -189,6 +194,11 @@
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
 				drive-open-drain;
 			};
 
@@ -204,6 +214,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+				bias-pull-down;
+			};
+
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
@@ -212,6 +227,10 @@
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_MASTER_NSS */
@@ -224,6 +243,10 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
@@ -232,6 +255,10 @@
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -244,6 +271,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
@@ -252,6 +283,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* SPI_SLAVE_NSS */
@@ -266,6 +301,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
@@ -274,6 +314,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
@@ -452,6 +496,12 @@
 
 			/* UART_CTS / USART_CTS */
 
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -477,6 +527,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -330,16 +330,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -394,32 +410,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -434,8 +482,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -520,6 +576,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -542,6 +604,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -456,16 +456,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -520,32 +536,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -560,8 +608,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -690,6 +746,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -712,6 +774,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -242,6 +242,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -254,7 +259,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -262,11 +276,19 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
@@ -281,6 +303,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -299,6 +326,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -311,6 +342,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -327,6 +362,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -341,6 +380,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -353,6 +396,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -371,6 +418,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -384,6 +436,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -564,7 +620,57 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -591,6 +697,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -638,6 +748,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -666,6 +784,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -456,16 +456,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -520,32 +536,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -560,8 +608,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -690,6 +746,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -712,6 +774,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -242,6 +242,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -254,7 +259,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -262,11 +276,19 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
@@ -281,6 +303,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -299,6 +326,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -311,6 +342,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -327,6 +362,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -341,6 +380,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -353,6 +396,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -371,6 +418,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -384,6 +436,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -564,7 +620,57 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -591,6 +697,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -638,6 +748,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -666,6 +784,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -464,16 +464,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -536,32 +552,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -588,8 +636,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -746,6 +802,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -768,6 +830,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -242,6 +242,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -254,7 +259,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -262,11 +276,19 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
@@ -281,6 +303,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -299,6 +326,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -311,6 +342,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -327,6 +362,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -341,6 +380,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -353,6 +396,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -371,6 +418,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -384,6 +436,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -508,6 +564,14 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
 			};
 
+			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
 			};
@@ -596,6 +660,50 @@
 				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
@@ -613,6 +721,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -639,6 +753,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -686,6 +804,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -714,6 +840,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -464,16 +464,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -536,32 +552,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -588,8 +636,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -746,6 +802,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -768,6 +830,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -242,6 +242,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -254,7 +259,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -262,11 +276,19 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
@@ -281,6 +303,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -299,6 +326,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -311,6 +342,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
@@ -327,6 +362,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -341,6 +380,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -353,6 +396,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -371,6 +418,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
 				bias-pull-up;
@@ -384,6 +436,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -508,6 +564,14 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
 			};
 
+			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
 			};
@@ -596,6 +660,50 @@
 				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+			};
+
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
@@ -613,6 +721,12 @@
 			};
 
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -639,6 +753,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -686,6 +804,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -714,6 +840,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -198,6 +198,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -210,7 +215,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -222,6 +236,10 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -231,6 +249,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
@@ -249,6 +271,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -272,6 +299,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -288,6 +319,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
@@ -308,6 +343,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -326,6 +365,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -342,6 +385,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -364,6 +411,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
 				bias-pull-up;
@@ -382,6 +434,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -522,7 +578,29 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -537,6 +615,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -568,6 +650,14 @@
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -588,6 +678,14 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -458,16 +458,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -494,32 +510,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -534,8 +582,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -614,6 +670,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -626,6 +688,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -206,6 +206,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -218,7 +223,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -230,6 +244,10 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -239,6 +257,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
@@ -257,6 +279,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -280,6 +307,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -296,6 +327,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
@@ -316,6 +351,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -334,6 +373,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -350,6 +393,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -372,6 +419,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
 				bias-pull-up;
@@ -390,6 +442,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -574,7 +630,29 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -601,6 +679,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -648,6 +730,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -676,6 +766,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -466,16 +466,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -530,32 +546,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -570,8 +618,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -672,6 +728,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -694,6 +756,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -206,6 +206,11 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pb10: i2c2_scl_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -218,7 +223,16 @@
 				drive-open-drain;
 			};
 
+			i2c2_sda_pb11: i2c2_sda_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* I2S_CK */
+
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
@@ -230,6 +244,10 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -239,6 +257,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
@@ -257,6 +279,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -280,6 +307,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -296,6 +327,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
@@ -316,6 +351,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -334,6 +373,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -350,6 +393,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -372,6 +419,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
 				bias-pull-up;
@@ -390,6 +442,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -574,7 +630,29 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -601,6 +679,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -648,6 +730,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -676,6 +766,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -466,16 +466,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -530,32 +546,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -570,8 +618,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -672,6 +728,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -694,6 +756,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -212,6 +212,10 @@
 
 			/* I2S_CK */
 
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -222,6 +226,10 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -231,6 +239,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
@@ -249,6 +261,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -272,6 +289,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -288,6 +309,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
@@ -308,6 +333,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -326,6 +355,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -342,6 +375,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -364,6 +401,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
 				bias-pull-up;
@@ -382,6 +424,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -522,7 +568,29 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -537,6 +605,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -568,6 +640,14 @@
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -588,6 +668,14 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -448,16 +448,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -484,32 +500,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -524,8 +572,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -604,6 +660,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -616,6 +678,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			/* UART_RX / USART_RX */

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -220,6 +220,10 @@
 
 			/* I2S_CK */
 
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -230,6 +234,10 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -239,6 +247,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
@@ -257,6 +269,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -280,6 +297,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -296,6 +317,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
@@ -316,6 +341,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -334,6 +363,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -350,6 +383,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -372,6 +409,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
 				bias-pull-up;
@@ -390,6 +432,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -574,7 +620,29 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -601,6 +669,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -648,6 +720,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -676,6 +756,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -456,16 +456,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -520,32 +536,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -560,8 +608,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -662,6 +718,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -684,6 +746,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -220,6 +220,10 @@
 
 			/* I2S_CK */
 
+			i2s2_ck_pb13: i2s2_ck_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -230,6 +234,10 @@
 
 			/* I2S_SD */
 
+			i2s2_sd_pb15: i2s2_sd_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			i2s3_sd_pb5: i2s3_sd_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -239,6 +247,10 @@
 			};
 
 			/* I2S_WS */
+
+			i2s2_ws_pb12: i2s2_ws_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
@@ -257,6 +269,11 @@
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				bias-pull-down;
+			};
+
+			spi2_miso_master_pb14: spi2_miso_master_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
 				bias-pull-down;
 			};
 
@@ -280,6 +297,10 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
 			};
@@ -296,6 +317,10 @@
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+			};
+
+			spi2_nss_master_pb12: spi2_nss_master_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
@@ -316,6 +341,10 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_sck_master_pb13: spi2_sck_master_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
 			};
@@ -334,6 +363,10 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
 			};
 
+			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
 			};
@@ -350,6 +383,10 @@
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
@@ -372,6 +409,11 @@
 				bias-pull-up;
 			};
 
+			spi2_nss_slave_pb12: spi2_nss_slave_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+			};
+
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
 				bias-pull-up;
@@ -390,6 +432,10 @@
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+			};
+
+			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
@@ -574,7 +620,29 @@
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
 			/* UART_CTS / USART_CTS */
+
+			usart1_cts_pa11: usart1_cts_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
@@ -601,6 +669,10 @@
 			};
 
 			/* UART_RTS / USART_RTS */
+
+			usart1_rts_pa12: usart1_rts_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
@@ -648,6 +720,14 @@
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
 			};
 
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			uart5_rx_pd2: uart5_rx_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+			};
+
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -676,6 +756,14 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+			};
+
+			uart5_tx_pc12: uart5_tx_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -456,16 +456,32 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+			};
+
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
@@ -520,32 +536,64 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+			};
+
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
 			};
 
+			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+			};
+
+			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
 			};
 
+			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+			};
+
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+			};
+
+			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
@@ -560,8 +608,16 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+			};
+
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+			};
+
+			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
@@ -662,6 +718,12 @@
 				drive-open-drain;
 			};
 
+			usart3_cts_pb13: usart3_cts_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
 				bias-pull-up;
@@ -684,6 +746,10 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+			};
+
+			usart3_rts_pb14: usart3_rts_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -410,6 +410,9 @@ def get_mcu_signals(cube_path, gpio_ip_afs):
                     pin_af = None
                 elif signal_name in pin_afs:
                     pin_af = pin_afs[signal_name]
+                # STM32F1: assume NO_REMAP (af=0) if signal is not listed in pin_afs
+                elif family == "STM32F1":
+                    pin_af = 0
                 else:
                     continue
 

--- a/scripts/tests/genpinctrl/data/cubemx/db/mcu/IP/GPIO-STM32F1TESTIP_Modes.xml
+++ b/scripts/tests/genpinctrl/data/cubemx/db/mcu/IP/GPIO-STM32F1TESTIP_Modes.xml
@@ -13,6 +13,10 @@
             <RemapBlock Name="UART1_REMAP0" DefaultRemap="true" />
             <RemapBlock Name="UART1_REMAP1">
             </RemapBlock>
+            <RemapBlock Name="UART1_REMAP2">
+            </RemapBlock>
+            <RemapBlock Name="UART1_REMAP3">
+            </RemapBlock>
         </PinSignal>
         <!-- Valid signal (single remap) -->
         <PinSignal Name="UART1_RX">

--- a/scripts/tests/genpinctrl/data/cubemx/db/mcu/STM32F1TESTDIE.xml
+++ b/scripts/tests/genpinctrl/data/cubemx/db/mcu/STM32F1TESTDIE.xml
@@ -9,5 +9,7 @@
         <Signal Name="UART1_RX"/>
         <!-- Valid signal (analog) -->
         <Signal Name="ADC1_IN0"/>
+        <!-- Valid signal (not in GPIO IP file) -->
+        <Signal Name="I2C2_SCL"/>
     </Pin>
 </Mcu>

--- a/scripts/tests/genpinctrl/data/stm32f1testdie-pinctrl.dtsi
+++ b/scripts/tests/genpinctrl/data/stm32f1testdie-pinctrl.dtsi
@@ -16,6 +16,13 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
 			};
 
+			/* I2C_SCL */
+
+			i2c2_scl_pa0: i2c2_scl_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX */
 
 			uart1_rx_pa0: uart1_rx_pa0 {

--- a/scripts/tests/genpinctrl/data/stm32f1testdie-pinctrl.dtsi
+++ b/scripts/tests/genpinctrl/data/stm32f1testdie-pinctrl.dtsi
@@ -35,6 +35,18 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
+			uart1_tx_pa0: uart1_tx_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_1)>;
+			};
+
+			uart1_tx_pa0: uart1_tx_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+			};
+
+			uart1_tx_pa0: uart1_tx_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_FULL)>;
+			};
+
 		};
 	};
 };

--- a/scripts/tests/genpinctrl/test_genpinctrl.py
+++ b/scripts/tests/genpinctrl/test_genpinctrl.py
@@ -207,6 +207,7 @@ def test_get_mcu_signals(cubemx):
                             {"name": "UART1_TX", "af": 0},
                             {"name": "UART1_RX", "af": 1},
                             {"name": "ADC1_IN0", "af": None},
+                            {"name": "I2C2_SCL", "af": 0},
                         ],
                     },
                 ],

--- a/scripts/tests/genpinctrl/test_genpinctrl.py
+++ b/scripts/tests/genpinctrl/test_genpinctrl.py
@@ -148,7 +148,7 @@ def test_format_remap():
     assert format_remap(0) == "NO_REMAP"
     assert format_remap(1) == "REMAP_1"
     assert format_remap(2) == "REMAP_2"
-    assert format_remap(3) == "FULL_REMAP"
+    assert format_remap(3) == "REMAP_FULL"
 
     with pytest.raises(ValueError):
         format_remap(5)
@@ -167,8 +167,8 @@ def test_get_gpio_ip_afs(cubemx):
         },
         "STM32F1TESTIP": {
             "PA0": {
-                "UART1_TX": 0,
-                "UART1_RX": 1,
+                "UART1_TX": [0, 1, 2, 3],
+                "UART1_RX": [1],
             }
         },
     }
@@ -205,6 +205,9 @@ def test_get_mcu_signals(cubemx):
                         "pin": 0,
                         "signals": [
                             {"name": "UART1_TX", "af": 0},
+                            {"name": "UART1_TX", "af": 1},
+                            {"name": "UART1_TX", "af": 2},
+                            {"name": "UART1_TX", "af": 3},
                             {"name": "UART1_RX", "af": 1},
                             {"name": "ADC1_IN0", "af": None},
                             {"name": "I2C2_SCL", "af": 0},


### PR DESCRIPTION
When working with F1 series pins not present in the GPIO IP files need to be taken into account with the `NO_REMAP` setting. Furthermore, only first remap block was being processed, now all of them are taken into account.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/29120