### PR TITLE
Add support for Ethernet pins

### DIFF
--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -186,6 +186,134 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -194,6 +194,158 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_crs_dv_pd8: eth_crs_dv_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_rxd0_pd9: eth_rxd0_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_rxd1_pd10: eth_rxd1_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_rxd2_pd11: eth_rxd2_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_rxd3_pd12: eth_rxd3_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_rx_dv_pd8: eth_rx_dv_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -194,6 +194,158 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_crs_dv_pd8: eth_crs_dv_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_rxd0_pd9: eth_rxd0_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_rxd1_pd10: eth_rxd1_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_rxd2_pd11: eth_rxd2_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_rxd3_pd12: eth_rxd3_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			eth_rx_dv_pd8: eth_rx_dv_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, REMAP_1)>;
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -256,6 +256,186 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -256,6 +256,186 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -256,6 +256,186 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -256,6 +256,186 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -268,6 +268,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -268,6 +268,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -268,6 +268,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -268,6 +268,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -268,6 +268,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -272,6 +272,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -231,6 +231,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -263,6 +263,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -249,6 +249,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -249,6 +249,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -281,6 +281,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -249,6 +249,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -249,6 +249,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -249,6 +249,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -249,6 +249,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -281,6 +281,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -281,6 +281,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -286,6 +286,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -286,6 +286,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -249,6 +249,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -249,6 +249,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -281,6 +281,171 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -286,6 +286,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -295,6 +295,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -294,6 +294,186 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -294,6 +294,187 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -294,6 +294,187 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -194,6 +194,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -194,6 +194,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -294,6 +294,186 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -194,6 +194,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -194,6 +194,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -194,6 +194,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -358,6 +358,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -358,6 +358,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -238,6 +238,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -238,6 +238,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -234,6 +234,156 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -294,6 +294,187 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -194,6 +194,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -294,6 +294,186 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -194,6 +194,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -194,6 +194,151 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -358,6 +358,196 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -238,6 +238,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -294,6 +294,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -266,6 +266,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -358,6 +358,201 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_col_ph3: eth_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_crs_ph2: eth_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd2_ph6: eth_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rxd3_ph7: eth_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_rx_er_pi10: eth_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd0_pg13: eth_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg12: eth_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd1_pg14: eth_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_tx_en_pg11: eth_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -234,6 +234,156 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* ETH_COL */
+
+			eth_col_pa3: eth_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS */
+
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_CRS_DV */
+
+			eth_crs_dv_pa7: eth_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDC */
+
+			eth_mdc_pc1: eth_mdc_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_MDIO */
+
+			eth_mdio_pa2: eth_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_PPS_OUT */
+
+			eth_pps_out_pb5: eth_pps_out_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_pps_out_pg8: eth_pps_out_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_REF_CLK */
+
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD0 */
+
+			eth_rxd0_pc4: eth_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD1 */
+
+			eth_rxd1_pc5: eth_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD2 */
+
+			eth_rxd2_pb0: eth_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RXD3 */
+
+			eth_rxd3_pb1: eth_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_DV */
+
+			eth_rx_dv_pa7: eth_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RX_ER */
+
+			eth_rx_er_pb10: eth_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD0 */
+
+			eth_txd0_pb12: eth_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD1 */
+
+			eth_txd1_pb13: eth_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TXD3 */
+
+			eth_txd3_pb8: eth_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			eth_txd3_pe2: eth_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_EN */
+
+			eth_tx_en_pb11: eth_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -48,6 +48,106 @@
   match: "^DAC(?:\\d+)?_OUT\\d+$"
   mode: analog
 
+- name: ETH_COL
+  match: "^ETH_COL$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_CRS
+  match: "^ETH_CRS$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_CRS_DV
+  match: "^ETH_CRS_DV$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_MDC
+  match: "^ETH_MDC$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_MDIO
+  match: "^ETH_MDIO$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_PPS_OUT
+  match: "^ETH_PPS_OUT$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_REF_CLK
+  match: "^ETH_REF_CLK$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_RX_CLK
+  match: "^ETH_RX_CLK$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_RX_DV
+  match: "^ETH_RX_DV$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_RX_ER
+  match: "^ETH_RX_ER$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_RXD0
+  match: "^ETH_RXD0$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_RXD1
+  match: "^ETH_RXD1$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_RXD2
+  match: "^ETH_RXD2$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_RXD3
+  match: "^ETH_RXD3$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_TX_CLK
+  match: "^ETH_TX_CLK$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_TX_EN
+  match: "^ETH_TX_EN$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_TXD0
+  match: "^ETH_TXD0$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_TXD1
+  match: "^ETH_TXD1$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_TXD2
+  match: "^ETH_TXD2$"
+  mode: alternate
+  slew-rate: very-high-speed
+
+- name: ETH_TXD3
+  match: "^ETH_TXD3$"
+  mode: alternate
+  slew-rate: very-high-speed
+
 - name: FDCAN_RX
   match: "^FDCAN\\d+_RX$"
   mode: alternate

--- a/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
@@ -50,6 +50,94 @@
   match: "^DAC_OUT\\d+$"
   mode: analog
 
+- name: ETH_COL
+  match: "^ETH_COL$"
+  mode: input
+
+- name: ETH_CRS
+  match: "^ETH_CRS$"
+  mode: input
+
+- name: ETH_CRS_DV
+  match: "^ETH_CRS_DV$"
+  mode: input
+
+- name: ETH_MDC
+  match: "^ETH_MDC$"
+  mode: alternate
+  slew-rate: max-speed-50mhz
+
+- name: ETH_MDIO
+  match: "^ETH_MDIO$"
+  mode: alternate
+  slew-rate: max-speed-50mhz
+
+- name: ETH_PPS_OUT
+  match: "^ETH_PPS_OUT$"
+  mode: alternate
+  slew-rate: max-speed-50mhz
+
+- name: ETH_REF_CLK
+  match: "^ETH_REF_CLK$"
+  mode: input
+
+- name: ETH_RX_CLK
+  match: "^ETH_RX_CLK$"
+  mode: input
+
+- name: ETH_RX_DV
+  match: "^ETH_RX_DV$"
+  mode: input
+
+- name: ETH_RX_ER
+  match: "^ETH_RX_ER$"
+  mode: input
+
+- name: ETH_RXD0
+  match: "^ETH_RXD0$"
+  mode: input
+
+- name: ETH_RXD1
+  match: "^ETH_RXD1$"
+  mode: input
+
+- name: ETH_RXD2
+  match: "^ETH_RXD2$"
+  mode: input
+
+- name: ETH_RXD3
+  match: "^ETH_RXD3$"
+  mode: input
+
+- name: ETH_TX_CLK
+  match: "^ETH_TX_CLK$"
+  mode: input
+
+- name: ETH_TX_EN
+  match: "^ETH_TX_EN$"
+  mode: alternate
+  slew-rate: max-speed-50mhz
+
+- name: ETH_TXD0
+  match: "^ETH_TXD0$"
+  mode: alternate
+  slew-rate: max-speed-50mhz
+
+- name: ETH_TXD1
+  match: "^ETH_TXD1$"
+  mode: alternate
+  slew-rate: max-speed-50mhz
+
+- name: ETH_TXD2
+  match: "^ETH_TXD2$"
+  mode: alternate
+  slew-rate: max-speed-50mhz
+
+- name: ETH_TXD3
+  match: "^ETH_TXD3$"
+  mode: alternate
+  slew-rate: max-speed-50mhz
+
 - name: I2C_SCL
   match: "^I2C\\d+_SCL$"
   drive: open-drain


### PR DESCRIPTION
F1 settings taken from RM0008 Rev 20, Table 209.
Other series settings are taken from current Zephyr settings. Note that
they will likely need to be adjusted, as very-high-speed is not needed
for all signals.