### PR TITLE
dts: Add USB signals

### DIFF
--- a/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
@@ -464,6 +464,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pa15: usb_noe_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
@@ -464,6 +464,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pa15: usb_noe_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f042f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f4px-pinctrl.dtsi
@@ -273,6 +273,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f042f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f6px-pinctrl.dtsi
@@ -273,6 +273,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
@@ -378,6 +378,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pa15: usb_noe_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
@@ -388,6 +388,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pa15: usb_noe_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
@@ -388,6 +388,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pa15: usb_noe_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
@@ -388,6 +388,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pa15: usb_noe_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
@@ -442,6 +442,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pa15: usb_noe_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
@@ -344,6 +344,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pa15: usb_noe_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
@@ -370,6 +370,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pa15: usb_noe_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
@@ -322,6 +322,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
@@ -430,6 +430,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f070f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070f6px-pinctrl.dtsi
@@ -219,6 +219,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa4: usb_noe_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
@@ -513,6 +513,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
@@ -548,6 +548,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
@@ -548,6 +548,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
@@ -548,6 +548,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
@@ -635,6 +635,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
@@ -635,6 +635,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f072rbix-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbix-pinctrl.dtsi
@@ -635,6 +635,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
@@ -810,6 +810,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
@@ -810,6 +810,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
@@ -526,6 +526,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f078cbux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbux-pinctrl.dtsi
@@ -526,6 +526,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
@@ -526,6 +526,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
@@ -613,6 +613,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
@@ -613,6 +613,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
@@ -779,6 +779,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
@@ -779,6 +779,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -310,6 +310,16 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -398,6 +398,16 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -350,6 +350,16 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -446,6 +446,16 @@
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -426,6 +426,16 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -514,6 +514,16 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -426,6 +426,16 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -514,6 +514,16 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -482,6 +482,16 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -490,6 +490,16 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -578,6 +578,16 @@
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -586,6 +586,16 @@
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -752,6 +752,16 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -740,6 +740,16 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -784,6 +784,16 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -380,6 +380,16 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -388,6 +388,16 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -674,6 +674,16 @@
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -674,6 +674,16 @@
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -840,6 +840,16 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -840,6 +840,16 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -880,6 +880,16 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -674,6 +674,16 @@
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -860,6 +860,16 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -860,6 +860,16 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -916,6 +916,16 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -916,6 +916,16 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -754,6 +754,28 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -842,6 +842,28 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -842,6 +842,28 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -744,6 +744,28 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -832,6 +832,28 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -832,6 +832,28 @@
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
 			};
 
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+			};
+
+			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, GPIO_IN, NO_REMAP)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
@@ -785,23 +785,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
@@ -785,23 +785,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f205rgex-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205rgex-pinctrl.dtsi
@@ -785,23 +785,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -888,23 +888,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -981,23 +981,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -1094,23 +1094,98 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -1094,23 +1094,98 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -888,23 +888,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -981,23 +981,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
@@ -785,23 +785,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -888,23 +888,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -981,23 +981,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -1094,23 +1094,98 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -1094,23 +1094,98 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -888,23 +888,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -981,23 +981,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
@@ -597,6 +597,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
@@ -716,6 +716,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
@@ -911,6 +911,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
@@ -869,6 +869,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
@@ -669,6 +669,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
@@ -816,6 +816,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
@@ -1103,6 +1103,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
@@ -1037,6 +1037,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
@@ -793,6 +793,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
@@ -977,6 +977,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
@@ -1104,6 +1104,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
@@ -1104,6 +1104,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
@@ -463,23 +463,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
@@ -463,23 +463,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
@@ -463,23 +463,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
@@ -463,23 +463,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
@@ -463,23 +463,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
@@ -555,23 +555,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
@@ -555,23 +555,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
@@ -696,23 +696,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
@@ -686,23 +686,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
@@ -696,23 +696,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
@@ -686,23 +686,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
@@ -882,23 +882,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
@@ -803,23 +803,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -906,23 +906,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -999,23 +999,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -1116,23 +1116,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -1116,23 +1116,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -906,23 +906,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -999,23 +999,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
@@ -590,23 +590,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
@@ -590,23 +590,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
@@ -691,23 +691,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
@@ -920,23 +920,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
@@ -910,23 +910,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
@@ -675,23 +675,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
@@ -817,23 +817,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
@@ -817,23 +817,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
@@ -817,23 +817,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
@@ -1075,23 +1075,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
@@ -1066,23 +1066,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
@@ -1175,23 +1175,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
@@ -1175,23 +1175,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
@@ -793,23 +793,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
@@ -1059,23 +1059,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
@@ -953,23 +953,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -1261,23 +1261,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -1252,23 +1252,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -1397,23 +1397,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -1397,23 +1397,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
@@ -882,23 +882,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
@@ -803,23 +803,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -906,23 +906,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -999,23 +999,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -1116,23 +1116,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -1116,23 +1116,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -906,23 +906,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -999,23 +999,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f423chux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423chux-pinctrl.dtsi
@@ -793,23 +793,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
@@ -1059,23 +1059,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
@@ -953,23 +953,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -1261,23 +1261,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -1252,23 +1252,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -1397,23 +1397,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -1397,23 +1397,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -1165,23 +1165,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -982,23 +982,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -1129,23 +1129,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -1165,23 +1165,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -982,23 +982,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -982,23 +982,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -1129,23 +1129,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -1129,23 +1129,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -1129,23 +1129,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -1129,23 +1129,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -1165,23 +1165,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -982,23 +982,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -1129,23 +1129,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -1165,23 +1165,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -1261,23 +1261,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -982,23 +982,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -1129,23 +1129,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -1129,23 +1129,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -994,23 +994,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -934,23 +934,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -1127,23 +1127,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -1254,23 +1254,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -1254,23 +1254,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -1254,23 +1254,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -1124,23 +1124,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -1124,23 +1124,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -1279,23 +1279,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -1232,23 +1232,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -1232,23 +1232,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -1232,23 +1232,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -1279,23 +1279,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -1279,23 +1279,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -932,23 +932,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -932,23 +932,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -1046,23 +1046,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -1046,23 +1046,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -1124,23 +1124,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -1124,23 +1124,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -1279,23 +1279,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -1232,23 +1232,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -1232,23 +1232,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -1279,23 +1279,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -932,23 +932,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -1046,23 +1046,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1361,23 +1361,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1361,23 +1361,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -861,23 +861,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -1072,23 +1072,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -1211,23 +1211,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1317,23 +1317,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1317,23 +1317,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -1019,23 +1019,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -1167,23 +1167,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -1167,23 +1167,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1317,23 +1317,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -861,23 +861,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -1072,23 +1072,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -1167,23 +1167,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1361,23 +1361,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1361,23 +1361,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -861,23 +861,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -1072,23 +1072,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -1211,23 +1211,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1317,23 +1317,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1317,23 +1317,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -1019,23 +1019,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -1167,23 +1167,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -1167,23 +1167,40 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -1102,23 +1102,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -1102,23 +1102,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1273,23 +1273,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -1102,23 +1102,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -1102,23 +1102,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -1102,23 +1102,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1273,23 +1273,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1273,23 +1273,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1273,23 +1273,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -1102,23 +1102,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1273,23 +1273,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -1417,23 +1417,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -1102,23 +1102,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -1102,23 +1102,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1273,23 +1273,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1273,23 +1273,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -1295,23 +1295,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -1295,23 +1295,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -1489,23 +1489,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -1295,23 +1295,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -1295,23 +1295,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -1295,23 +1295,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -1295,23 +1295,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -1489,23 +1489,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -1489,23 +1489,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -1484,23 +1484,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -1484,23 +1484,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -1578,23 +1578,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -1578,23 +1578,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -1295,23 +1295,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -1295,23 +1295,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -1489,23 +1489,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -1484,23 +1484,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -1484,23 +1484,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -1578,23 +1578,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -1651,23 +1651,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -1643,23 +1643,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -1799,23 +1799,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -1704,23 +1704,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -1704,23 +1704,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -1288,23 +1288,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -1288,23 +1288,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -1530,23 +1530,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -1643,23 +1643,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -1799,23 +1799,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -1799,23 +1799,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -1714,23 +1714,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -1714,23 +1714,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -1714,23 +1714,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -1714,23 +1714,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -1288,23 +1288,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -1288,23 +1288,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -1288,23 +1288,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -1530,23 +1530,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1530,23 +1530,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -1799,23 +1799,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -1799,23 +1799,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -1722,23 +1722,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -1607,23 +1607,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -1722,23 +1722,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -1607,23 +1607,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -1484,23 +1484,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -1484,23 +1484,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -1530,23 +1530,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -1714,23 +1714,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -1714,23 +1714,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -1530,23 +1530,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -1530,23 +1530,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1369,23 +1369,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -1714,23 +1714,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -1704,23 +1704,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -1288,23 +1288,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -1530,23 +1530,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -1643,23 +1643,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -1799,23 +1799,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -1714,23 +1714,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -1714,23 +1714,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -1288,23 +1288,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -1288,23 +1288,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -1530,23 +1530,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -1799,23 +1799,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -1722,23 +1722,90 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -1607,23 +1607,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -1484,23 +1484,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -1530,23 +1530,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -1714,23 +1714,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -1530,23 +1530,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -1863,23 +1863,94 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1369,23 +1369,86 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
+			/* USB_OTG_HS */
 
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_hs_sof_pa4: usb_otg_hs_sof_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF12)>;
+			};
+
+			usb_otg_hs_dp_pb15: usb_otg_hs_dp_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -1653,6 +1653,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -1706,6 +1706,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -1704,6 +1704,66 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -1706,6 +1706,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -1627,6 +1627,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -1857,6 +1857,70 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -1803,6 +1803,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -1423,6 +1423,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -1062,6 +1062,58 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -1318,6 +1318,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -1282,6 +1282,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -1318,6 +1318,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -1225,6 +1225,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -1550,6 +1550,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -1511,6 +1511,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -1653,6 +1653,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -1704,6 +1704,66 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -1706,6 +1706,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -1062,6 +1062,58 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -1318,6 +1318,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -1550,6 +1550,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -1653,6 +1653,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -1706,6 +1706,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -1704,6 +1704,66 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -1706,6 +1706,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -1627,6 +1627,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -1857,6 +1857,70 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -1803,6 +1803,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -1423,6 +1423,62 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -1062,6 +1062,58 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -1318,6 +1318,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -1282,6 +1282,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -1318,6 +1318,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -1225,6 +1225,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -1550,6 +1550,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -1511,6 +1511,54 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			/* USB_OTG_HS_ULPI */
+
+			usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
@@ -397,6 +397,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
@@ -254,6 +254,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
@@ -260,6 +260,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
@@ -454,6 +454,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
@@ -467,6 +467,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
@@ -301,6 +301,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
@@ -301,6 +301,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
@@ -397,6 +397,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
@@ -454,6 +454,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
@@ -467,6 +467,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
@@ -254,6 +254,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
@@ -260,6 +260,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
@@ -397,6 +397,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
@@ -467,6 +467,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
@@ -524,6 +524,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
@@ -524,6 +524,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
@@ -562,6 +562,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072czex-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072czex-pinctrl.dtsi
@@ -562,6 +562,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
@@ -384,6 +384,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
@@ -335,6 +335,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
@@ -642,6 +642,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
@@ -642,6 +642,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
@@ -655,6 +655,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
@@ -524,6 +524,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
@@ -524,6 +524,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
@@ -642,6 +642,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
@@ -655,6 +655,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l073rzix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073rzix-pinctrl.dtsi
@@ -642,6 +642,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l082czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czux-pinctrl.dtsi
@@ -524,6 +524,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l082czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czyx-pinctrl.dtsi
@@ -562,6 +562,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
@@ -384,6 +384,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
@@ -335,6 +335,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
@@ -524,6 +524,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l083czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083czux-pinctrl.dtsi
@@ -524,6 +524,12 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
@@ -642,6 +642,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
@@ -655,6 +655,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF2)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF2)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
@@ -394,6 +394,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
@@ -394,6 +394,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
@@ -443,6 +443,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
@@ -443,6 +443,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l100rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100rctx-pinctrl.dtsi
@@ -525,6 +525,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
@@ -394,6 +394,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
@@ -394,6 +394,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
@@ -394,6 +394,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
@@ -394,6 +394,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151cctx-pinctrl.dtsi
@@ -469,6 +469,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ccux-pinctrl.dtsi
@@ -469,6 +469,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qchx-pinctrl.dtsi
@@ -743,6 +743,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
@@ -761,6 +761,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qehx-pinctrl.dtsi
@@ -765,6 +765,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
@@ -439,6 +439,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
@@ -439,6 +439,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
@@ -443,6 +443,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
@@ -443,6 +443,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctx-pinctrl.dtsi
@@ -541,6 +541,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
@@ -541,6 +541,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
@@ -541,6 +541,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
@@ -559,6 +559,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
@@ -559,6 +559,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151retx-pinctrl.dtsi
@@ -559,6 +559,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
@@ -541,6 +541,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
@@ -605,6 +605,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
@@ -605,6 +605,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
@@ -605,6 +605,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
@@ -605,6 +605,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vchx-pinctrl.dtsi
@@ -715,6 +715,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctx-pinctrl.dtsi
@@ -715,6 +715,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
@@ -711,6 +711,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
@@ -729,6 +729,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
@@ -733,6 +733,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
@@ -733,6 +733,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vetx-pinctrl.dtsi
@@ -733,6 +733,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151veyx-pinctrl.dtsi
@@ -733,6 +733,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zctx-pinctrl.dtsi
@@ -747,6 +747,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
@@ -765,6 +765,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l151zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zetx-pinctrl.dtsi
@@ -769,6 +769,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
@@ -394,6 +394,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
@@ -394,6 +394,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
@@ -394,6 +394,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
@@ -394,6 +394,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152cctx-pinctrl.dtsi
@@ -469,6 +469,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ccux-pinctrl.dtsi
@@ -469,6 +469,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qchx-pinctrl.dtsi
@@ -743,6 +743,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
@@ -761,6 +761,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qehx-pinctrl.dtsi
@@ -765,6 +765,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
@@ -439,6 +439,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
@@ -439,6 +439,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
@@ -443,6 +443,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
@@ -443,6 +443,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctx-pinctrl.dtsi
@@ -541,6 +541,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
@@ -541,6 +541,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
@@ -559,6 +559,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
@@ -559,6 +559,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152retx-pinctrl.dtsi
@@ -559,6 +559,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
@@ -541,6 +541,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
@@ -605,6 +605,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
@@ -605,6 +605,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
@@ -605,6 +605,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
@@ -605,6 +605,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vchx-pinctrl.dtsi
@@ -715,6 +715,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctx-pinctrl.dtsi
@@ -715,6 +715,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
@@ -711,6 +711,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
@@ -729,6 +729,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
@@ -733,6 +733,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vetx-pinctrl.dtsi
@@ -733,6 +733,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152veyx-pinctrl.dtsi
@@ -733,6 +733,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zctx-pinctrl.dtsi
@@ -747,6 +747,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
@@ -765,6 +765,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l152zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zetx-pinctrl.dtsi
@@ -769,6 +769,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
@@ -761,6 +761,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctx-pinctrl.dtsi
@@ -541,6 +541,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
@@ -541,6 +541,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
@@ -559,6 +559,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
@@ -559,6 +559,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162retx-pinctrl.dtsi
@@ -559,6 +559,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vchx-pinctrl.dtsi
@@ -715,6 +715,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctx-pinctrl.dtsi
@@ -715,6 +715,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
@@ -711,6 +711,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
@@ -729,6 +729,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
@@ -733,6 +733,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vetx-pinctrl.dtsi
@@ -733,6 +733,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162veyx-pinctrl.dtsi
@@ -733,6 +733,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
@@ -765,6 +765,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l1/stm32l162zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zetx-pinctrl.dtsi
@@ -769,6 +769,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
@@ -528,6 +528,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
@@ -528,6 +528,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
@@ -528,6 +528,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
@@ -499,6 +499,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbux-pinctrl.dtsi
@@ -528,6 +528,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
@@ -499,6 +499,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
@@ -366,6 +366,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
@@ -366,6 +366,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
@@ -366,6 +366,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbux-pinctrl.dtsi
@@ -366,6 +366,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
@@ -631,6 +631,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
@@ -631,6 +631,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbix-pinctrl.dtsi
@@ -631,6 +631,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
@@ -613,6 +613,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
@@ -631,6 +631,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
@@ -613,6 +613,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
@@ -384,6 +384,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
@@ -384,6 +384,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
@@ -374,6 +374,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
@@ -528,6 +528,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l422cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbux-pinctrl.dtsi
@@ -528,6 +528,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
@@ -366,6 +366,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l422kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbux-pinctrl.dtsi
@@ -366,6 +366,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l422rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbix-pinctrl.dtsi
@@ -631,6 +631,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
@@ -631,6 +631,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
@@ -384,6 +384,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
@@ -382,6 +382,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -553,6 +553,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -553,6 +553,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -562,6 +562,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -647,6 +647,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -647,6 +647,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -647,6 +647,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -633,6 +633,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -770,6 +770,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -770,6 +770,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l442kcux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l442kcux-pinctrl.dtsi
@@ -382,6 +382,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -553,6 +553,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -553,6 +553,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -562,6 +562,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -647,6 +647,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -647,6 +647,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -647,6 +647,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -770,6 +770,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -770,6 +770,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
@@ -636,6 +636,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -767,6 +767,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -767,6 +767,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -767,6 +767,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -753,6 +753,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -918,6 +918,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -918,6 +918,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l462ceux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462ceux-pinctrl.dtsi
@@ -636,6 +636,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -767,6 +767,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -767,6 +767,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -767,6 +767,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -918,6 +918,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -918,6 +918,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -827,23 +827,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -986,23 +986,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -892,23 +892,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -865,23 +865,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -925,23 +925,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -1128,23 +1128,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -827,23 +827,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -986,23 +986,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -1172,23 +1172,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -1172,23 +1172,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -1153,23 +1153,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -892,23 +892,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -892,23 +892,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -1128,23 +1128,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -827,23 +827,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -986,23 +986,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -1172,23 +1172,22 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
-			};
-
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -1395,23 +1395,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -1391,23 +1391,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -1290,23 +1290,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -1259,23 +1259,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -960,23 +960,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -938,23 +938,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -1136,23 +1136,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -1133,23 +1133,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -1121,23 +1121,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -1334,23 +1334,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -1309,23 +1309,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -1395,23 +1395,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -1391,23 +1391,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -1290,23 +1290,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -1259,23 +1259,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -960,23 +960,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -938,23 +938,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -1136,23 +1136,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -1133,23 +1133,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -1121,23 +1121,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -1334,23 +1334,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -1309,23 +1309,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -1338,23 +1338,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -1334,23 +1334,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -723,23 +723,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -723,23 +723,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -679,23 +679,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -679,23 +679,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -1237,23 +1237,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -1206,23 +1206,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -893,23 +893,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -875,23 +875,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -1095,23 +1095,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -1092,23 +1092,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -1066,23 +1066,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -1080,23 +1080,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -1261,23 +1261,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -1236,23 +1236,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -1274,23 +1274,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -723,23 +723,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -723,23 +723,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -1237,23 +1237,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -893,23 +893,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -1095,23 +1095,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -1092,23 +1092,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -1261,23 +1261,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -1274,23 +1274,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -1173,23 +1173,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -1031,23 +1031,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -1197,23 +1197,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -1164,23 +1164,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -1172,23 +1172,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -1274,23 +1274,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -1031,23 +1031,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -1197,23 +1197,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -1254,23 +1254,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -983,23 +983,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -1176,23 +1176,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -1165,23 +1165,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -1164,23 +1164,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -1133,23 +1133,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -1274,23 +1274,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -1173,23 +1173,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -1031,23 +1031,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -1197,23 +1197,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -1164,23 +1164,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -1274,23 +1274,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -1031,23 +1031,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -1197,23 +1197,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -1254,23 +1254,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -983,23 +983,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -1176,23 +1176,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -1165,23 +1165,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -1164,23 +1164,26 @@
 				bias-pull-up;
 			};
 
-			/* USB_OTG_FS_DM */
+			/* USB_OTG_FS */
+
+			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
+			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
 
 			usb_otg_fs_dm_pa11: usb_otg_fs_dm_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			/* USB_OTG_FS_DP */
-
 			usb_otg_fs_dp_pa12: usb_otg_fs_dp_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			/* USB_OTG_FS_ID */
-
-			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF10)>;
-				bias-pull-up;
+			usb_otg_fs_sof_pa14: usb_otg_fs_sof_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
 		};

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -715,6 +715,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -715,6 +715,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -667,6 +667,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -667,6 +667,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -970,6 +970,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -947,6 +947,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -1189,6 +1189,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -1216,6 +1216,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -1201,6 +1201,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -894,6 +894,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -872,6 +872,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -810,6 +810,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -1034,6 +1034,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -1074,6 +1074,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -1189,6 +1189,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -1240,6 +1240,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -715,6 +715,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -667,6 +667,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -715,6 +715,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -667,6 +667,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -970,6 +970,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -947,6 +947,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -1074,6 +1074,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -1201,6 +1201,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -1189,6 +1189,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -894,6 +894,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -872,6 +872,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -810,6 +810,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -1074,6 +1074,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -1034,6 +1034,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -1240,6 +1240,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -1189,6 +1189,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -2019,6 +2019,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -1485,6 +1485,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -1934,6 +1934,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -1485,6 +1485,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -2019,6 +2019,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -1485,6 +1485,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -1934,6 +1934,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -1485,6 +1485,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -2019,6 +2019,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -1485,6 +1485,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -1934,6 +1934,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -1485,6 +1485,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -2019,6 +2019,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -1485,6 +1485,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -1934,6 +1934,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -1485,6 +1485,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -2075,6 +2075,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -1990,6 +1990,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -2075,6 +2075,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -1990,6 +1990,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -2075,6 +2075,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -1990,6 +1990,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -2075,6 +2075,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -1990,6 +1990,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -2075,6 +2075,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -1990,6 +1990,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -2075,6 +2075,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -1990,6 +1990,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -2075,6 +2075,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -1990,6 +1990,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -2075,6 +2075,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -1990,6 +1990,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -1529,6 +1529,12 @@
 				bias-pull-up;
 			};
 
+			/* USB_OTG_HS */
+
+			usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb35c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb35c(c-e)ux-pinctrl.dtsi
@@ -462,6 +462,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb35c(c-e)yx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb35c(c-e)yx-pinctrl.dtsi
@@ -323,6 +323,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
@@ -334,6 +334,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
@@ -334,6 +334,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
@@ -334,6 +334,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -504,6 +504,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -504,6 +504,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -504,6 +504,20 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -535,6 +535,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -535,6 +535,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -535,6 +535,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -535,6 +535,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -535,6 +535,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -535,6 +535,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -535,6 +535,24 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			usb_noe_pa13: usb_noe_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+			};
+
+			usb_noe_pc9: usb_noe_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
 		};
 	};
 };

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -129,15 +129,18 @@
   match: "^(?:LP)?US?ART\\d+_RX$"
   mode: alternate
 
-- name: USB_OTG_FS_DM
-  match: "^USB_OTG_FS_DM$"
+- name: USB_OTG_FS
+  match: "^USB_OTG_FS_(?:DM)?(?:DP)?(?:SOF)?(?:ID)?(?:VBUS)?$"
   mode: alternate
 
-- name: USB_OTG_FS_DP
-  match: "^USB_OTG_FS_DP$"
+- name: USB_OTG_HS
+  match: "^USB_OTG_HS_(?:DM)?(?:DP)?(?:SOF)?(?:ID)?(?:VBUS)?$"
   mode: alternate
 
-- name: USB_OTG_FS_ID
-  match: "^USB_OTG_FS_ID$"
+- name: USB_OTG_HS_ULPI
+  match: "^USB_OTG_HS_ULPI_(?:DIR)?(?:STP)?(?:NXT)?(?:D\\d+)?$"
   mode: alternate
-  bias: pull-up
+
+- name: USB
+  match: "^USB_(?:DM)?(?:DP)?(?:NOE)?$"
+  mode: alternate

--- a/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
@@ -136,3 +136,11 @@
 - name: UART_RX / USART_RX
   match: "^US?ART\\d+_RX$"
   mode: input
+
+- name: USB_OTG_FS
+  match: "^USB_OTG_FS_(?:DM)?(?:DP)?(?:SOF)?(?:ID)?(?:VBUS)?$"
+  mode: input
+
+- name: USB
+  match: "^USB_(?:DM)?(?:DP)?$"
+  mode: input


### PR DESCRIPTION
Add USB signals for most STM32 parts.

Due to script limitation, some parts that use analog mode for USB pins are missing the required signals for now.
This concerns some F302 parts and at least some L0 (if not all).
An issue has been open to fix this limitation: https://github.com/zephyrproject-rtos/zephyr/issues/29368.