### PR TITLE
scripts/genpinctrl:  Add generation of "additional functions" for non F1 series

### DIFF
--- a/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf6: i2c1_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -100,6 +106,12 @@
 
 			i2c1_sda_pb11: i2c1_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf7: i2c1_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
@@ -72,6 +72,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf6: i2c2_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -88,6 +94,12 @@
 
 			i2c2_sda_pb11: i2c2_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf7: i2c2_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
@@ -96,6 +96,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf6: i2c2_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -112,6 +118,12 @@
 
 			i2c2_sda_pb11: i2c2_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf7: i2c2_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf6: i2c1_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -100,6 +106,12 @@
 
 			i2c1_sda_pb11: i2c1_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf7: i2c1_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pf6: i2c1_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pa10: i2c1_sda_pa10 {
@@ -100,6 +106,12 @@
 
 			i2c1_sda_pb11: i2c1_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pf7: i2c1_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pb13: i2c1_scl_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pf1: i2c1_scl_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF1)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb11: i2c1_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pb14: i2c1_sda_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -470,6 +482,14 @@
 
 			usb_noe_pa4: usb_noe_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			usb_noe_pa13: usb_noe_pa13 {

--- a/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
@@ -106,6 +106,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pb13: i2c1_scl_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pf1: i2c1_scl_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF1)>;
 				bias-pull-up;
@@ -140,6 +146,12 @@
 
 			i2c1_sda_pb11: i2c1_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pb14: i2c1_sda_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -470,6 +482,14 @@
 
 			usb_noe_pa4: usb_noe_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			usb_noe_pa13: usb_noe_pa13 {

--- a/dts/st/f0/stm32f042f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f4px-pinctrl.dtsi
@@ -280,6 +280,14 @@
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f042f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f6px-pinctrl.dtsi
@@ -280,6 +280,14 @@
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
@@ -386,6 +386,14 @@
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
@@ -396,6 +396,14 @@
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
@@ -396,6 +396,14 @@
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
@@ -396,6 +396,14 @@
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
@@ -84,6 +84,12 @@
 				drive-open-drain;
 			};
 
+			i2c1_scl_pb13: i2c1_scl_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			i2c1_scl_pf1: i2c1_scl_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF1)>;
 				bias-pull-up;
@@ -118,6 +124,12 @@
 
 			i2c1_sda_pb11: i2c1_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c1_sda_pb14: i2c1_sda_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -448,6 +460,14 @@
 
 			usb_noe_pa4: usb_noe_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
+			};
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			usb_noe_pa13: usb_noe_pa13 {

--- a/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
@@ -352,6 +352,14 @@
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
@@ -378,6 +378,14 @@
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf6: i2c2_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -94,6 +100,12 @@
 
 			i2c2_sda_pb11: i2c2_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf7: i2c2_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf6: i2c2_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -94,6 +100,12 @@
 
 			i2c2_sda_pb11: i2c2_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf7: i2c2_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
@@ -102,6 +102,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf6: i2c2_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -118,6 +124,12 @@
 
 			i2c2_sda_pb11: i2c2_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf7: i2c2_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
@@ -102,6 +102,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf6: i2c2_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -118,6 +124,12 @@
 
 			i2c2_sda_pb11: i2c2_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf7: i2c2_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
@@ -78,6 +78,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf6: i2c2_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -94,6 +100,12 @@
 
 			i2c2_sda_pb11: i2c2_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf7: i2c2_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
@@ -102,6 +102,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf6: i2c2_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -118,6 +124,12 @@
 
 			i2c2_sda_pb11: i2c2_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf7: i2c2_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
@@ -102,6 +102,12 @@
 				drive-open-drain;
 			};
 
+			i2c2_scl_pf6: i2c2_scl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
@@ -118,6 +124,12 @@
 
 			i2c2_sda_pb11: i2c2_sda_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			i2c2_sda_pf7: i2c2_sda_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
@@ -328,6 +328,14 @@
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
@@ -432,6 +432,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f070f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070f6px-pinctrl.dtsi
@@ -225,6 +225,14 @@
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
@@ -515,6 +515,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
@@ -554,6 +554,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
@@ -554,6 +554,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
@@ -554,6 +554,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
@@ -641,6 +641,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
@@ -641,6 +641,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f072rbix-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbix-pinctrl.dtsi
@@ -641,6 +641,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
@@ -818,6 +818,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
@@ -818,6 +818,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
@@ -532,6 +532,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f078cbux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbux-pinctrl.dtsi
@@ -532,6 +532,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
@@ -532,6 +532,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
@@ -619,6 +619,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
@@ -619,6 +619,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
@@ -787,6 +787,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
@@ -787,6 +787,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
@@ -791,6 +791,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
@@ -791,6 +791,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f205rgex-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205rgex-pinctrl.dtsi
@@ -791,6 +791,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -894,6 +894,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -987,6 +987,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -1290,6 +1290,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -1290,6 +1290,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -1039,6 +1039,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -1152,6 +1152,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
@@ -791,6 +791,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -894,6 +894,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -987,6 +987,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -1290,6 +1290,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -1290,6 +1290,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -1039,6 +1039,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -1152,6 +1152,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
@@ -561,6 +561,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
@@ -561,6 +561,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
@@ -411,6 +411,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
@@ -641,6 +641,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
@@ -799,6 +799,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -1039,6 +1039,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -1039,6 +1039,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -1043,6 +1043,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
@@ -899,6 +899,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -1259,6 +1259,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -1259,6 +1259,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f303veyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303veyx-pinctrl.dtsi
@@ -1187,6 +1187,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -1311,6 +1311,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
@@ -472,6 +472,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
@@ -472,6 +472,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
@@ -472,6 +472,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
@@ -472,6 +472,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
@@ -472,6 +472,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
@@ -565,6 +565,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
@@ -565,6 +565,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
@@ -707,6 +707,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
@@ -697,6 +697,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
@@ -707,6 +707,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
@@ -697,6 +697,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
@@ -893,6 +893,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -913,6 +917,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
@@ -813,6 +813,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -833,6 +837,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -916,6 +916,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -936,6 +940,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -1009,6 +1009,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1029,6 +1033,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -1317,6 +1317,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1337,6 +1341,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -1317,6 +1317,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1337,6 +1341,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -1061,6 +1061,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1081,6 +1085,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -1174,6 +1174,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1194,6 +1198,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
@@ -893,6 +893,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -913,6 +917,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
@@ -813,6 +813,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -833,6 +837,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -916,6 +916,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -936,6 +940,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -1009,6 +1009,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1029,6 +1033,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -1317,6 +1317,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1337,6 +1341,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -1317,6 +1317,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1337,6 +1341,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -1061,6 +1061,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1081,6 +1085,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -1174,6 +1174,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1194,6 +1198,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -1357,6 +1357,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1377,6 +1381,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -1138,6 +1138,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1158,6 +1162,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -1305,6 +1305,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1325,6 +1329,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -1357,6 +1357,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1377,6 +1381,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -1138,6 +1138,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1158,6 +1162,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -1138,6 +1138,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1158,6 +1162,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -1305,6 +1305,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1325,6 +1329,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -1305,6 +1305,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1325,6 +1329,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -1305,6 +1305,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1325,6 +1329,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -1305,6 +1305,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1325,6 +1329,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -1357,6 +1357,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1377,6 +1381,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -1138,6 +1138,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1158,6 +1162,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -1305,6 +1305,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1325,6 +1329,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -1357,6 +1357,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1377,6 +1381,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -1463,6 +1463,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1483,6 +1487,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -1138,6 +1138,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1158,6 +1162,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -1305,6 +1305,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1325,6 +1329,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -1305,6 +1305,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1325,6 +1329,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -1008,6 +1008,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1028,6 +1032,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -948,6 +948,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -968,6 +972,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -1142,6 +1142,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1162,6 +1166,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -1269,6 +1269,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1289,6 +1293,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -1269,6 +1269,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1289,6 +1293,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -1269,6 +1269,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1289,6 +1293,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -1137,6 +1137,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1157,6 +1161,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -1137,6 +1137,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1157,6 +1161,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -1482,6 +1482,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1502,6 +1506,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -1435,6 +1435,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1455,6 +1459,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -1435,6 +1435,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1455,6 +1459,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -1435,6 +1435,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1455,6 +1459,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -1482,6 +1482,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1502,6 +1506,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -1482,6 +1482,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1502,6 +1506,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -944,6 +944,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -964,6 +968,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -944,6 +944,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -964,6 +968,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -1058,6 +1058,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1078,6 +1082,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -1058,6 +1058,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1078,6 +1082,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -1137,6 +1137,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1157,6 +1161,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -1137,6 +1137,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1157,6 +1161,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -1482,6 +1482,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1502,6 +1506,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -1435,6 +1435,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1455,6 +1459,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -1435,6 +1435,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1455,6 +1459,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -1482,6 +1482,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1502,6 +1506,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -944,6 +944,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -964,6 +968,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -1058,6 +1058,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1078,6 +1082,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1498,6 +1498,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1518,6 +1522,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1498,6 +1498,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1518,6 +1522,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -926,6 +926,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -946,6 +950,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -1188,6 +1188,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1208,6 +1212,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -1347,6 +1347,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1367,6 +1371,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1444,6 +1444,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1464,6 +1468,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1444,6 +1444,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1464,6 +1468,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -1085,6 +1085,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1105,6 +1109,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -1293,6 +1293,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1313,6 +1317,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -1293,6 +1293,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1313,6 +1317,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1444,6 +1444,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1464,6 +1468,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -926,6 +926,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -946,6 +950,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -1188,6 +1188,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1208,6 +1212,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -1293,6 +1293,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1313,6 +1317,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1498,6 +1498,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1518,6 +1522,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1498,6 +1498,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1518,6 +1522,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -926,6 +926,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -946,6 +950,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -1188,6 +1188,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1208,6 +1212,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -1347,6 +1347,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1367,6 +1371,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1444,6 +1444,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1464,6 +1468,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1444,6 +1444,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1464,6 +1468,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -1085,6 +1085,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1105,6 +1109,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -1293,6 +1293,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1313,6 +1317,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -1293,6 +1293,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1313,6 +1317,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -1313,6 +1313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1333,6 +1337,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -1313,6 +1313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1333,6 +1337,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1504,6 +1504,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1524,6 +1528,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -1313,6 +1313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1333,6 +1337,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -1313,6 +1313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1333,6 +1337,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -1313,6 +1313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1333,6 +1337,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1504,6 +1504,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1524,6 +1528,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1504,6 +1504,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1524,6 +1528,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1504,6 +1504,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1524,6 +1528,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -1313,6 +1313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1333,6 +1337,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1504,6 +1504,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1524,6 +1528,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -1674,6 +1674,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1694,6 +1698,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -1313,6 +1313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1333,6 +1337,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -1313,6 +1313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1333,6 +1337,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1504,6 +1504,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1524,6 +1528,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1504,6 +1504,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1524,6 +1528,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -1557,6 +1557,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1577,6 +1581,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -1557,6 +1557,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1577,6 +1581,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -1792,6 +1792,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1812,6 +1816,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -1557,6 +1557,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1577,6 +1581,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -1557,6 +1557,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1577,6 +1581,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -1557,6 +1557,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1577,6 +1581,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -1557,6 +1557,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1577,6 +1581,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -1792,6 +1792,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1812,6 +1816,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -1792,6 +1792,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1812,6 +1816,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -1623,6 +1623,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1643,6 +1647,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -1623,6 +1623,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1643,6 +1647,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -1907,6 +1907,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1927,6 +1931,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -1907,6 +1907,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1927,6 +1931,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -1557,6 +1557,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1577,6 +1581,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -1557,6 +1557,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1577,6 +1581,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -1792,6 +1792,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1812,6 +1816,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -1623,6 +1623,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1643,6 +1647,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -1623,6 +1623,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1643,6 +1647,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -1907,6 +1907,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1927,6 +1931,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -1980,6 +1980,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2000,6 +2004,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
@@ -787,6 +787,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
@@ -848,6 +848,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
@@ -585,6 +585,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
@@ -585,6 +585,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
@@ -1048,6 +1048,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
@@ -987,6 +987,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
@@ -987,6 +987,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -1169,6 +1169,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
@@ -787,6 +787,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g441cbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbux-pinctrl.dtsi
@@ -848,6 +848,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
@@ -829,6 +829,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
@@ -585,6 +585,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g441kbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbux-pinctrl.dtsi
@@ -585,6 +585,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
@@ -1048,6 +1048,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g441rbix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbix-pinctrl.dtsi
@@ -987,6 +987,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
@@ -987,6 +987,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -1169,6 +1169,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -847,6 +847,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -914,6 +914,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -1205,6 +1205,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -1215,6 +1215,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -1502,6 +1502,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -1084,6 +1084,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -1371,6 +1371,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -1371,6 +1371,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -1371,6 +1371,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -891,6 +891,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -958,6 +958,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -1321,6 +1321,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -1339,6 +1339,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -1726,6 +1726,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -1136,6 +1136,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -891,6 +891,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -958,6 +958,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -1321,6 +1321,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -1339,6 +1339,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -1726,6 +1726,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -1136,6 +1136,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -891,6 +891,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -958,6 +958,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -1321,6 +1321,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -1339,6 +1339,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -1726,6 +1726,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -1136,6 +1136,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g483veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483veix-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -891,6 +891,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -958,6 +958,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -1321,6 +1321,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -1339,6 +1339,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -1726,6 +1726,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -1136,6 +1136,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g484veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484veix-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -1551,6 +1551,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
@@ -864,6 +864,16 @@
 				bias-pull-up;
 			};
 
+			/* USB */
+
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -1977,6 +1977,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1997,6 +2001,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -2148,6 +2148,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2168,6 +2172,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -2039,6 +2039,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2059,6 +2063,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -2039,6 +2039,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2059,6 +2063,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -1580,6 +1580,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1600,6 +1604,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -1580,6 +1580,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1600,6 +1604,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -1853,6 +1853,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1873,6 +1877,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -1977,6 +1977,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1997,6 +2001,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -2148,6 +2148,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2168,6 +2172,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -2148,6 +2148,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2168,6 +2172,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -2063,6 +2063,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2083,6 +2087,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -2063,6 +2063,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2083,6 +2087,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -2063,6 +2063,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2083,6 +2087,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -2063,6 +2063,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2083,6 +2087,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -1580,6 +1580,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1600,6 +1604,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -1580,6 +1580,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1600,6 +1604,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -1580,6 +1580,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1600,6 +1604,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -1853,6 +1853,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1873,6 +1877,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1853,6 +1853,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1873,6 +1877,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -2148,6 +2148,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2168,6 +2172,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -2148,6 +2148,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2168,6 +2172,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -2065,6 +2065,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2085,6 +2089,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -1930,6 +1930,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1950,6 +1954,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -2065,6 +2065,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2085,6 +2089,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -1930,6 +1930,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1950,6 +1954,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -1807,6 +1807,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1827,6 +1831,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -1807,6 +1807,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1827,6 +1831,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -1853,6 +1853,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1873,6 +1877,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -2063,6 +2063,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2083,6 +2087,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -2063,6 +2063,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2083,6 +2087,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -1853,6 +1853,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1873,6 +1877,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -1853,6 +1853,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1873,6 +1877,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1666,6 +1666,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1686,6 +1690,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -2063,6 +2063,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2083,6 +2087,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -2039,6 +2039,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2059,6 +2063,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -1580,6 +1580,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1600,6 +1604,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -1853,6 +1853,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1873,6 +1877,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -1977,6 +1977,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1997,6 +2001,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -2148,6 +2148,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2168,6 +2172,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -2063,6 +2063,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2083,6 +2087,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -2063,6 +2063,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2083,6 +2087,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -1580,6 +1580,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1600,6 +1604,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -1580,6 +1580,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1600,6 +1604,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -1853,6 +1853,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1873,6 +1877,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -2148,6 +2148,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2168,6 +2172,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -2065,6 +2065,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2085,6 +2089,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -1930,6 +1930,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1950,6 +1954,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -1807,6 +1807,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1827,6 +1831,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -1853,6 +1853,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1873,6 +1877,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -2063,6 +2063,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2083,6 +2087,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -1853,6 +1853,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1873,6 +1877,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -2212,6 +2212,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -2232,6 +2236,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1666,6 +1666,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
@@ -1686,6 +1690,10 @@
 
 			usb_otg_hs_id_pb12: usb_otg_hs_id_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+			};
+
+			usb_otg_hs_vbus_pb13: usb_otg_hs_vbus_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
 			usb_otg_hs_dm_pb14: usb_otg_hs_dm_pb14 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -1840,8 +1840,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -1894,8 +1894,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -1891,8 +1891,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -1894,8 +1894,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -1814,8 +1814,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -2045,8 +2045,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -1991,8 +1991,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -1605,8 +1605,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -1201,8 +1201,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -1473,8 +1473,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -1437,8 +1437,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -1473,8 +1473,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -1370,8 +1370,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -1737,8 +1737,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -1698,8 +1698,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -1840,8 +1840,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -1891,8 +1891,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -1894,8 +1894,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -1201,8 +1201,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -1473,8 +1473,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -1737,8 +1737,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -1840,8 +1840,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -1894,8 +1894,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -1891,8 +1891,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -1894,8 +1894,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -1814,8 +1814,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -2045,8 +2045,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -1991,8 +1991,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -1605,8 +1605,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -1201,8 +1201,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -1473,8 +1473,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -1437,8 +1437,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -1473,8 +1473,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -1370,8 +1370,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -1737,8 +1737,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -1698,8 +1698,20 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_vbus_pa9: usb_otg_hs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
+			};
+
+			usb_otg_hs_dm_pa11: usb_otg_hs_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_otg_hs_dp_pa12: usb_otg_hs_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
 			};
 
 			/* USB_OTG_HS_ULPI */

--- a/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
@@ -206,6 +206,10 @@
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -260,6 +264,12 @@
 
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
@@ -206,6 +206,10 @@
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -284,6 +288,12 @@
 
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l031c6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c6ux-pinctrl.dtsi
@@ -206,6 +206,10 @@
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -284,6 +288,12 @@
 
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
@@ -206,6 +206,10 @@
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
@@ -284,6 +288,12 @@
 
 			lpuart1_cts_pb13: lpuart1_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 				bias-pull-up;
 				drive-open-drain;
 			};

--- a/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
@@ -400,6 +400,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
@@ -256,6 +256,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
@@ -262,6 +262,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
@@ -457,6 +457,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
@@ -470,6 +470,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
@@ -303,6 +303,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
@@ -303,6 +303,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
@@ -400,6 +400,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
@@ -457,6 +457,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
@@ -470,6 +470,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
@@ -256,6 +256,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
@@ -262,6 +262,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
@@ -400,6 +400,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
@@ -470,6 +470,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
@@ -527,6 +527,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
@@ -527,6 +527,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
@@ -565,6 +565,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072czex-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072czex-pinctrl.dtsi
@@ -565,6 +565,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
@@ -386,6 +386,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
@@ -337,6 +337,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
@@ -645,6 +645,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
@@ -645,6 +645,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
@@ -658,6 +658,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
@@ -527,6 +527,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
@@ -527,6 +527,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
@@ -645,6 +645,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
@@ -658,6 +658,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l073rzix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073rzix-pinctrl.dtsi
@@ -645,6 +645,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l082czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czux-pinctrl.dtsi
@@ -527,6 +527,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l082czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czyx-pinctrl.dtsi
@@ -565,6 +565,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
@@ -386,6 +386,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
@@ -337,6 +337,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
@@ -527,6 +527,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l083czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083czux-pinctrl.dtsi
@@ -527,6 +527,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
@@ -645,6 +645,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
@@ -658,6 +658,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
@@ -833,6 +833,14 @@
 
 			/* USB */
 
+			usb_dm_pa11: usb_dm_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			usb_dp_pa12: usb_dp_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
 			usb_noe_pa13: usb_noe_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};

--- a/dts/st/l1/stm32l151qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qchx-pinctrl.dtsi
@@ -616,6 +616,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
@@ -616,6 +616,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
@@ -584,6 +584,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
@@ -584,6 +584,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l151zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zctx-pinctrl.dtsi
@@ -620,6 +620,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
@@ -620,6 +620,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l152qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qchx-pinctrl.dtsi
@@ -616,6 +616,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
@@ -616,6 +616,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
@@ -584,6 +584,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
@@ -584,6 +584,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l152zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zctx-pinctrl.dtsi
@@ -620,6 +620,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
@@ -620,6 +620,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
@@ -616,6 +616,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
@@ -584,6 +584,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
@@ -584,6 +584,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
@@ -620,6 +620,10 @@
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
+			tim9_ch2_pe6: tim9_ch2_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
 			/* UART_CTS / USART_CTS / LPUART_CTS */
 
 			usart1_cts_pa11: usart1_cts_pa11 {

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -885,6 +885,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -1044,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -950,6 +950,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -923,6 +923,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -983,6 +983,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -1186,6 +1186,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -885,6 +885,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -1044,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -1230,6 +1230,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -1230,6 +1230,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -1211,6 +1211,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -950,6 +950,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -950,6 +950,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -1186,6 +1186,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -885,6 +885,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -1044,6 +1044,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -1230,6 +1230,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -1453,6 +1453,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -1449,6 +1449,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -1348,6 +1348,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -1317,6 +1317,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -1018,6 +1018,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -944,6 +944,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -1194,6 +1194,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -1191,6 +1191,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -1179,6 +1179,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -1392,6 +1392,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -1367,6 +1367,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -1453,6 +1453,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -1449,6 +1449,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -1348,6 +1348,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -1317,6 +1317,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -1018,6 +1018,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -991,6 +991,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -1194,6 +1194,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -1191,6 +1191,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -1179,6 +1179,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -1392,6 +1392,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -1367,6 +1367,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -1531,6 +1531,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -1527,6 +1527,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -771,6 +771,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -771,6 +771,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -722,6 +722,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -722,6 +722,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -1430,6 +1430,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -1399,6 +1399,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -1031,6 +1031,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -1008,6 +1008,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -1248,6 +1248,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -1265,6 +1265,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -1219,6 +1219,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -1253,6 +1253,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -1454,6 +1454,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -1429,6 +1429,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -1467,6 +1467,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -771,6 +771,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -771,6 +771,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -1430,6 +1430,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -1031,6 +1031,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -1248,6 +1248,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -1265,6 +1265,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -1454,6 +1454,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -1352,6 +1352,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -1251,6 +1251,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -1109,6 +1109,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -1275,6 +1275,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -1242,6 +1242,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -1250,6 +1250,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -1352,6 +1352,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -1109,6 +1109,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -1275,6 +1275,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -1332,6 +1332,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -1061,6 +1061,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -1254,6 +1254,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -1243,6 +1243,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -1242,6 +1242,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -1211,6 +1211,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -1352,6 +1352,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -1251,6 +1251,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -1109,6 +1109,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -1275,6 +1275,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -1242,6 +1242,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -1352,6 +1352,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -1109,6 +1109,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -1275,6 +1275,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -1332,6 +1332,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -1061,6 +1061,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -1254,6 +1254,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -1243,6 +1243,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -1242,6 +1242,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_fs_vbus_pa9: usb_otg_fs_vbus_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
 			usb_otg_fs_id_pa10: usb_otg_fs_id_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -588,6 +588,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -588,6 +588,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -549,6 +549,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -549,6 +549,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -852,6 +852,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -829,6 +829,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -1022,6 +1022,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -1049,6 +1049,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -1034,6 +1034,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -787,6 +787,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -702,6 +702,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -717,6 +717,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -912,6 +912,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -937,6 +937,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -1037,6 +1037,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -1073,6 +1073,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -588,6 +588,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -549,6 +549,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -588,6 +588,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -549,6 +549,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -852,6 +852,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -829,6 +829,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -937,6 +937,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -1034,6 +1034,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -1022,6 +1022,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -787,6 +787,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -702,6 +702,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -717,6 +717,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -937,6 +937,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -912,6 +912,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -1073,6 +1073,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -1037,6 +1037,18 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart5_cts_pb5: uart5_cts_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -2398,6 +2398,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -1812,6 +1812,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -2313,6 +2313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -1812,6 +1812,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -2398,6 +2398,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -1812,6 +1812,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -2313,6 +2313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -1812,6 +1812,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -2398,6 +2398,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -1812,6 +1812,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -2313,6 +2313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -1812,6 +1812,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -2398,6 +2398,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -1812,6 +1812,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -2313,6 +2313,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -1812,6 +1812,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -2454,6 +2454,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -2369,6 +2369,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -2454,6 +2454,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -2369,6 +2369,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -2454,6 +2454,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -2369,6 +2369,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -2454,6 +2454,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -2369,6 +2369,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -2454,6 +2454,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -2369,6 +2369,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -2454,6 +2454,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -2369,6 +2369,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -2454,6 +2454,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -2369,6 +2369,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -2454,6 +2454,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -2369,6 +2369,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -1856,6 +1856,10 @@
 				pinmux = <STM32_PINMUX('A', 8, AF10)>;
 			};
 
+			usb_otg_hs_id_pa10: usb_otg_hs_id_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -11,10 +11,12 @@
 #     be as precise as possible. Note that it needs to be escaped here in the
 #     configuration file.
 #
-#   - mode (mandatory): Mode setting (analog, alternate). Mode needs to
+#   - mode (optional): Mode setting (analog, alternate). Mode needs to
 #     be set according to the following rules:
 #       * Pin operates in analog configuration: analog
 #       * Pin operates in alternate function configuration: alternate
+#     In default case, mode could be infered from CubeMX SoC description files
+#     and can be omitted.
 #
 #   - bias (optional): Bias setting (disable, pull-up, pull-down). Equivalent to
 #     "disable" (a.k.a floating) if not set.
@@ -33,167 +35,133 @@
 ---
 - name: ADC_IN / ADC_INN / ADC_INP
   match: "^ADC(?:\\d+)?_IN[NP]?\\d+$"
-  mode: analog
 
 - name: CAN_RX
   match: "^CAN\\d*_RX$"
-  mode: alternate
   bias: pull-up
 
 - name: CAN_TX
   match: "^CAN\\d*_TX$"
-  mode: alternate
 
 - name: DAC_OUT
   match: "^DAC(?:\\d+)?_OUT\\d+$"
-  mode: analog
 
 - name: ETH_COL
   match: "^ETH_COL$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_CRS
   match: "^ETH_CRS$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_CRS_DV
   match: "^ETH_CRS_DV$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_MDC
   match: "^ETH_MDC$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_MDIO
   match: "^ETH_MDIO$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_PPS_OUT
   match: "^ETH_PPS_OUT$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_REF_CLK
   match: "^ETH_REF_CLK$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_RX_CLK
   match: "^ETH_RX_CLK$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_RX_DV
   match: "^ETH_RX_DV$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_RX_ER
   match: "^ETH_RX_ER$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_RXD0
   match: "^ETH_RXD0$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_RXD1
   match: "^ETH_RXD1$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_RXD2
   match: "^ETH_RXD2$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_RXD3
   match: "^ETH_RXD3$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_TX_CLK
   match: "^ETH_TX_CLK$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_TX_EN
   match: "^ETH_TX_EN$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_TXD0
   match: "^ETH_TXD0$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_TXD1
   match: "^ETH_TXD1$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_TXD2
   match: "^ETH_TXD2$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: ETH_TXD3
   match: "^ETH_TXD3$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: FDCAN_RX
   match: "^FDCAN\\d+_RX$"
-  mode: alternate
 
 - name: FDCAN_TX
   match: "^FDCAN\\d+_TX$"
-  mode: alternate
 
 - name: I2C_SCL
   match: "^I2C\\d+_SCL$"
-  mode: alternate
   drive: open-drain
   bias: pull-up
 
 - name: I2C_SDA
   match: "^I2C\\d+_SDA$"
-  mode: alternate
   drive: open-drain
   bias: pull-up
 
 - name: I2S_CK
   match: "^I2S\\d+_CK$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: I2S_WS
   match: "^I2S\\d+_WS$"
-  mode: alternate
 
 - name: I2S_SD
   match: "^I2S\\d+_SD$"
-  mode: alternate
 
 - name: SDMMC
   match: "^SDMMC\\d+_(?:CK)?(?:CKIN)?(?:CDIR)?(?:CMD)?(?:D\\d+)?(?:D0DIR)?(?:D123DIR)?$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: SPI_MISO
   match: "^SPI\\d+_MISO$"
-  mode: alternate
   bias: pull-down
 
 - name: SPI_MOSI
   match: "^SPI\\d+_MOSI$"
-  mode: alternate
   bias: pull-down
 
 # NOTE: The SPI_SCK pins speed must be set to very-high-speed to avoid last data
@@ -201,51 +169,40 @@
 # peripheral (ref. ES0182 Rev 12, 2.5.12, p. 22).
 - name: SPI_SCK
   match: "^SPI\\d+_SCK$"
-  mode: alternate
   slew-rate: very-high-speed
 
 - name: SPI_NSS
   match: "^SPI\\d+_NSS$"
-  mode: alternate
   bias: pull-up
 
 - name: TIM_CH / TIM_CHN
   match: "^TIM\\d+_CH\\d+N?$"
-  mode: alternate
 
 - name: UART_CTS / USART_CTS / LPUART_CTS
   match: "^(?:LP)?US?ART\\d+_CTS$"
-  mode: alternate
   drive: open-drain
   bias: pull-up
 
 - name: UART_RTS / USART_RTS / LPUART_RTS
   match: "^(?:LP)?US?ART\\d+_RTS$"
-  mode: alternate
   drive: open-drain
   bias: pull-up
 
 - name: UART_TX / USART_TX / LPUART_TX
   match: "^(?:LP)?US?ART\\d+_TX$"
-  mode: alternate
   bias: pull-up
 
 - name: UART_RX / USART_RX / LPUART_RX
   match: "^(?:LP)?US?ART\\d+_RX$"
-  mode: alternate
 
 - name: USB_OTG_FS
   match: "^USB_OTG_FS_(?:DM)?(?:DP)?(?:SOF)?(?:ID)?(?:VBUS)?$"
-  mode: alternate
 
 - name: USB_OTG_HS
   match: "^USB_OTG_HS_(?:DM)?(?:DP)?(?:SOF)?(?:ID)?(?:VBUS)?$"
-  mode: alternate
 
 - name: USB_OTG_HS_ULPI
   match: "^USB_OTG_HS_ULPI_(?:DIR)?(?:STP)?(?:NXT)?(?:D\\d+)?$"
-  mode: alternate
 
 - name: USB
   match: "^USB_(?:DM)?(?:DP)?(?:NOE)?$"
-  mode: alternate

--- a/scripts/tests/genpinctrl/test_genpinctrl.py
+++ b/scripts/tests/genpinctrl/test_genpinctrl.py
@@ -26,10 +26,10 @@ def test_validate_config_entry():
     with pytest.raises(ValueError):
         validate_config_entry(entry, "")
 
-    # no mode
+    # no mode: F1 error only
     entry = {"name": "TEST", "match": "TEST"}
     with pytest.raises(ValueError):
-        validate_config_entry(entry, "")
+        validate_config_entry(entry, "STM32F1")
 
     # invalid mode
     entry = {"name": "TEST", "match": "TEST"}
@@ -209,7 +209,7 @@ def test_get_mcu_signals(cubemx):
                             {"name": "UART1_TX", "af": 2},
                             {"name": "UART1_TX", "af": 3},
                             {"name": "UART1_RX", "af": 1},
-                            {"name": "ADC1_IN0", "af": None},
+                            {"name": "ADC1_IN0", "af": 0},
                             {"name": "I2C2_SCL", "af": 0},
                         ],
                     },


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/29368

Generate signals for "additional functions" for pins on non F1 series.
Set mode as an optional parameters and by default infer its value (analog/alternate) from the result of the input files parsing.
For  a given pin signal, if an alternate function is found, consider mode as "alternate".
If not AF is found,consider the signal as valid, with mode as "analog". This matches the definition of "additional functions"
that could be found in ref manual and datasheets.
